### PR TITLE
Serve cached pages early

### DIFF
--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -364,30 +364,30 @@ class Cache {
      */
     public function serve_cache() {
         if (!$this->should_cache_page()) {
-            return false;
+            return;
         }
-        
+
         $cache_content = $this->get_cache_content();
-        
-        if ($cache_content !== false) {
-            // Headers de caché
-            $this->send_cache_headers();
-            
-            // Enviar contenido
-            echo $cache_content;
-            
-            // Log del hit de caché
-            if ($this->logger) {
-                $this->logger->debug('Cache hit served', [
-                    'url' => $this->get_current_url(),
-                    'cache_key' => $this->generate_cache_key()
-                ], 'cache');
-            }
-            
-            exit;
+
+        if ($cache_content === false) {
+            return;
         }
-        
-        return false;
+
+        // Headers de caché
+        $this->send_cache_headers();
+
+        // Enviar contenido
+        echo $cache_content;
+
+        // Log del hit de caché
+        if ($this->logger) {
+            $this->logger->debug('Cache hit served', [
+                'url' => $this->get_current_url(),
+                'cache_key' => $this->generate_cache_key()
+            ], 'cache');
+        }
+
+        exit;
     }
     
     /**

--- a/suple-speed.php
+++ b/suple-speed.php
@@ -176,6 +176,7 @@ class SupleSpeed {
     private function init_main_hooks() {
         // Solo ejecutar optimizaciones en frontend si no estamos en modo editor
         if (!is_admin() && !$this->elementor_guard->is_editor_mode()) {
+            add_action('template_redirect', [$this->cache, 'serve_cache'], 0);
             add_action('template_redirect', [$this, 'start_output_buffering'], 1);
             add_action('wp_enqueue_scripts', [$this->assets, 'optimize_scripts_styles'], 999);
             add_action('wp_head', [$this->assets, 'inject_critical_css'], 1);


### PR DESCRIPTION
## Summary
- serve cached pages early on template_redirect when in frontend outside Elementor editor
- ensure cache serving returns control cleanly when no cached response exists

## Testing
- php -l suple-speed.php
- php -l includes/class-cache.php

------
https://chatgpt.com/codex/tasks/task_e_68cbfa7d08148330b79ff0267be9d2bf