### PR TITLE
Add admin views for plugin sections

### DIFF
--- a/views/admin-assets.php
+++ b/views/admin-assets.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Página de optimización de assets
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$current_settings = $this->get_current_settings();
+$compat_module = function_exists('suple_speed') ? suple_speed()->compat : null;
+$excluded_by_compat = [];
+
+if ($compat_module && method_exists($compat_module, 'get_excluded_handles')) {
+    $excluded_by_compat = $compat_module->get_excluded_handles();
+}
+
+$manual_exclusions = $current_settings['assets_exclude_handles'] ?? [];
+?>
+
+<div class="suple-speed-admin">
+
+    <div class="suple-speed-header">
+        <h1><?php _e('Assets', 'suple-speed'); ?></h1>
+        <p><?php _e('Optimize CSS and JavaScript delivery across your pages.', 'suple-speed'); ?></p>
+    </div>
+
+    <?php include SUPLE_SPEED_PLUGIN_DIR . 'views/partials/admin-nav.php'; ?>
+
+    <div class="suple-grid suple-grid-2 suple-mt-2">
+        <div class="suple-card">
+            <h3><?php _e('Optimization Status', 'suple-speed'); ?></h3>
+
+            <ul class="suple-list">
+                <li>
+                    <strong><?php _e('Assets Optimization', 'suple-speed'); ?>:</strong>
+                    <span class="suple-badge <?php echo !empty($current_settings['assets_enabled']) ? 'success' : 'error'; ?>">
+                        <?php echo !empty($current_settings['assets_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                    </span>
+                </li>
+                <li>
+                    <strong><?php _e('Merge CSS', 'suple-speed'); ?>:</strong>
+                    <?php echo !empty($current_settings['merge_css']) ? esc_html__('Yes', 'suple-speed') : esc_html__('No', 'suple-speed'); ?>
+                </li>
+                <li>
+                    <strong><?php _e('Merge JS', 'suple-speed'); ?>:</strong>
+                    <?php echo !empty($current_settings['merge_js']) ? esc_html__('Yes', 'suple-speed') : esc_html__('No', 'suple-speed'); ?>
+                </li>
+                <li>
+                    <strong><?php _e('Test Mode', 'suple-speed'); ?>:</strong>
+                    <?php echo !empty($current_settings['assets_test_mode']) ? esc_html__('Active', 'suple-speed') : esc_html__('Inactive', 'suple-speed'); ?>
+                </li>
+            </ul>
+
+            <a class="suple-button" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-assets')); ?>">
+                <?php _e('Open Assets Settings', 'suple-speed'); ?>
+            </a>
+        </div>
+
+        <div class="suple-card">
+            <h3><?php _e('Excluded Handles', 'suple-speed'); ?></h3>
+
+            <p><?php _e('Handles skipped from optimization for compatibility reasons.', 'suple-speed'); ?></p>
+
+            <h4><?php _e('Manual Exclusions', 'suple-speed'); ?></h4>
+            <?php if (!empty($manual_exclusions)): ?>
+                <ul class="suple-list">
+                    <?php foreach ($manual_exclusions as $handle): ?>
+                        <li><?php echo esc_html($handle); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php else: ?>
+                <p><?php _e('No manual exclusions configured.', 'suple-speed'); ?></p>
+            <?php endif; ?>
+
+            <h4><?php _e('Compatibility Exclusions', 'suple-speed'); ?></h4>
+            <?php if (!empty($excluded_by_compat)): ?>
+                <ul class="suple-list">
+                    <?php foreach ($excluded_by_compat as $handle): ?>
+                        <li><?php echo esc_html($handle); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php else: ?>
+                <p><?php _e('No automatic exclusions detected.', 'suple-speed'); ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Manual Scan', 'suple-speed'); ?></h3>
+        <p><?php _e('Trigger a scan of the current page to detect enqueued handles and adjust optimization rules.', 'suple-speed'); ?></p>
+        <button type="button" class="suple-button suple-scan-assets">
+            <span class="dashicons dashicons-search"></span>
+            <?php _e('Scan Handles', 'suple-speed'); ?>
+        </button>
+    </div>
+</div>

--- a/views/admin-cache.php
+++ b/views/admin-cache.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Página de control de caché
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$cache_module = function_exists('suple_speed') ? suple_speed()->cache : null;
+$cache_stats = [
+    'total_files' => 0,
+    'total_size' => 0,
+    'total_size_formatted' => size_format(0),
+    'oldest_file' => null,
+    'newest_file' => null,
+];
+
+if ($cache_module && method_exists($cache_module, 'get_cache_stats')) {
+    $cache_stats = $cache_module->get_cache_stats();
+    if (empty($cache_stats['total_size_formatted'])) {
+        $cache_stats['total_size_formatted'] = size_format((int) ($cache_stats['total_size'] ?? 0));
+    }
+}
+
+$current_settings = $this->get_current_settings();
+?>
+
+<div class="suple-speed-admin">
+
+    <div class="suple-speed-header">
+        <h1><?php _e('Cache', 'suple-speed'); ?></h1>
+        <p><?php _e('Inspect cache usage and purge content when required.', 'suple-speed'); ?></p>
+    </div>
+
+    <?php include SUPLE_SPEED_PLUGIN_DIR . 'views/partials/admin-nav.php'; ?>
+
+    <div class="suple-grid suple-grid-2 suple-mt-2">
+        <div class="suple-card">
+            <h3><?php _e('Cache Status', 'suple-speed'); ?></h3>
+
+            <ul class="suple-list">
+                <li>
+                    <strong><?php _e('Status', 'suple-speed'); ?>:</strong>
+                    <span class="suple-badge <?php echo !empty($current_settings['cache_enabled']) ? 'success' : 'error'; ?>">
+                        <?php echo !empty($current_settings['cache_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                    </span>
+                </li>
+                <li>
+                    <strong><?php _e('Cache Size', 'suple-speed'); ?>:</strong>
+                    <?php echo esc_html($cache_stats['total_size_formatted']); ?>
+                </li>
+                <li>
+                    <strong><?php _e('Cached Files', 'suple-speed'); ?>:</strong>
+                    <?php echo esc_html($cache_stats['total_files']); ?>
+                </li>
+                <li>
+                    <strong><?php _e('Newest File', 'suple-speed'); ?>:</strong>
+                    <?php echo !empty($cache_stats['newest_file']) ? esc_html($cache_stats['newest_file']) : esc_html__('N/A', 'suple-speed'); ?>
+                </li>
+                <li>
+                    <strong><?php _e('Oldest File', 'suple-speed'); ?>:</strong>
+                    <?php echo !empty($cache_stats['oldest_file']) ? esc_html($cache_stats['oldest_file']) : esc_html__('N/A', 'suple-speed'); ?>
+                </li>
+            </ul>
+
+            <div class="suple-mt-2">
+                <button type="button" class="suple-button suple-purge-cache" data-purge-action="all">
+                    <span class="dashicons dashicons-update"></span>
+                    <?php _e('Purge Entire Cache', 'suple-speed'); ?>
+                </button>
+                <button type="button" class="suple-button secondary suple-purge-cache" data-purge-action="expired">
+                    <?php _e('Clean Expired Files', 'suple-speed'); ?>
+                </button>
+            </div>
+        </div>
+
+        <div class="suple-card">
+            <h3><?php _e('Quick Settings', 'suple-speed'); ?></h3>
+
+            <p><?php _e('These are the most relevant cache settings currently applied.', 'suple-speed'); ?></p>
+
+            <ul class="suple-list">
+                <li>
+                    <strong><?php _e('Cache Lifetime', 'suple-speed'); ?>:</strong>
+                    <?php
+                    $ttl_hours = !empty($current_settings['cache_ttl']) ? floor($current_settings['cache_ttl'] / HOUR_IN_SECONDS) : 0;
+                    echo $ttl_hours ? esc_html(sprintf(_n('%d hour', '%d hours', $ttl_hours, 'suple-speed'), $ttl_hours)) : esc_html__('Default', 'suple-speed');
+                    ?>
+                </li>
+                <li>
+                    <strong><?php _e('Compression', 'suple-speed'); ?>:</strong>
+                    <?php echo !empty($current_settings['compression_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                </li>
+                <li>
+                    <strong><?php _e('Logged-in Cache', 'suple-speed'); ?>:</strong>
+                    <?php echo !empty($current_settings['cache_logged_users']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                </li>
+            </ul>
+
+            <a class="suple-button" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-cache')); ?>">
+                <?php _e('Adjust Cache Settings', 'suple-speed'); ?>
+            </a>
+        </div>
+    </div>
+</div>

--- a/views/admin-compatibility.php
+++ b/views/admin-compatibility.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Página de compatibilidad
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$compat_module = function_exists('suple_speed') ? suple_speed()->compat : null;
+$compat_report = [
+    'detected_plugins' => [],
+    'potential_conflicts' => [],
+    'recommendations' => [],
+    'safe_mode_required' => false,
+];
+
+if ($compat_module && method_exists($compat_module, 'get_compatibility_report')) {
+    $compat_report = $compat_module->get_compatibility_report();
+}
+?>
+
+<div class="suple-speed-admin">
+
+    <div class="suple-speed-header">
+        <h1><?php _e('Compatibility', 'suple-speed'); ?></h1>
+        <p><?php _e('Review detected plugins and potential conflicts that may affect optimisation.', 'suple-speed'); ?></p>
+    </div>
+
+    <?php include SUPLE_SPEED_PLUGIN_DIR . 'views/partials/admin-nav.php'; ?>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Safe Mode', 'suple-speed'); ?></h3>
+        <?php if (!empty($compat_report['safe_mode_required'])): ?>
+            <p class="notice notice-warning">
+                <?php _e('Safe Mode is recommended due to detected compatibility issues.', 'suple-speed'); ?>
+            </p>
+        <?php else: ?>
+            <p><?php _e('No critical conflicts detected. Safe Mode is optional.', 'suple-speed'); ?></p>
+        <?php endif; ?>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Detected Plugins', 'suple-speed'); ?></h3>
+        <?php if (!empty($compat_report['detected_plugins'])): ?>
+            <table class="widefat">
+                <thead>
+                    <tr>
+                        <th><?php _e('Plugin', 'suple-speed'); ?></th>
+                        <th><?php _e('Status', 'suple-speed'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($compat_report['detected_plugins'] as $plugin_key => $plugin_info): ?>
+                        <tr>
+                            <td><?php echo esc_html($plugin_info['name'] ?? $plugin_key); ?></td>
+                            <td><?php echo !empty($plugin_info['active']) ? esc_html__('Active', 'suple-speed') : esc_html__('Inactive', 'suple-speed'); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <p><?php _e('No known integrations detected yet.', 'suple-speed'); ?></p>
+        <?php endif; ?>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Potential Conflicts', 'suple-speed'); ?></h3>
+        <?php if (!empty($compat_report['potential_conflicts'])): ?>
+            <ul class="suple-list">
+                <?php foreach ($compat_report['potential_conflicts'] as $conflict): ?>
+                    <li>
+                        <strong><?php echo esc_html($conflict['plugin'] ?? ''); ?></strong> –
+                        <?php echo esc_html($conflict['message'] ?? ''); ?>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php else: ?>
+            <p><?php _e('No conflicts detected.', 'suple-speed'); ?></p>
+        <?php endif; ?>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Recommendations', 'suple-speed'); ?></h3>
+        <?php if (!empty($compat_report['recommendations'])): ?>
+            <ul class="suple-list">
+                <?php foreach ($compat_report['recommendations'] as $recommendation): ?>
+                    <li><?php echo esc_html($recommendation); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        <?php else: ?>
+            <p><?php _e('Everything looks good! No extra actions required.', 'suple-speed'); ?></p>
+        <?php endif; ?>
+    </div>
+</div>

--- a/views/admin-critical.php
+++ b/views/admin-critical.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Página de Critical CSS y preloads
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$current_settings = $this->get_current_settings();
+$fonts_module = function_exists('suple_speed') ? suple_speed()->fonts : null;
+$font_preloads = [];
+
+if ($fonts_module && method_exists($fonts_module, 'get_font_preloads')) {
+    $font_preloads = $fonts_module->get_font_preloads();
+}
+
+$asset_preloads = $current_settings['preload_assets'] ?? [];
+$critical_css = $current_settings['critical_css'] ?? '';
+?>
+
+<div class="suple-speed-admin">
+
+    <div class="suple-speed-header">
+        <h1><?php _e('Critical & Preloads', 'suple-speed'); ?></h1>
+        <p><?php _e('Manage critical CSS snippets and resource preloads.', 'suple-speed'); ?></p>
+    </div>
+
+    <?php include SUPLE_SPEED_PLUGIN_DIR . 'views/partials/admin-nav.php'; ?>
+
+    <div class="suple-grid suple-grid-2 suple-mt-2">
+        <div class="suple-card">
+            <h3><?php _e('Critical CSS', 'suple-speed'); ?></h3>
+            <?php if (!empty($critical_css)): ?>
+                <p><?php _e('A custom critical CSS snippet is currently active.', 'suple-speed'); ?></p>
+                <textarea class="widefat" rows="6" readonly><?php echo esc_textarea(wp_trim_words($critical_css, 120, '…')); ?></textarea>
+            <?php else: ?>
+                <p><?php _e('No critical CSS has been configured yet. You can add one in the settings panel.', 'suple-speed'); ?></p>
+            <?php endif; ?>
+            <a class="suple-button" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-assets')); ?>">
+                <?php _e('Edit Critical CSS', 'suple-speed'); ?>
+            </a>
+        </div>
+
+        <div class="suple-card">
+            <h3><?php _e('Asset Preloads', 'suple-speed'); ?></h3>
+            <?php if (!empty($asset_preloads)): ?>
+                <ul class="suple-list">
+                    <?php foreach ($asset_preloads as $preload): ?>
+                        <li>
+                            <strong><?php echo esc_html($preload['type'] ?? ($preload['as'] ?? '')); ?></strong> –
+                            <span><?php echo esc_html($preload['url'] ?? ($preload['href'] ?? '')); ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php else: ?>
+                <p><?php _e('No asset preloads defined. Configure CSS/JS preloads to improve paint times.', 'suple-speed'); ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Font Preloads', 'suple-speed'); ?></h3>
+        <?php if (!empty($font_preloads)): ?>
+            <table class="widefat">
+                <thead>
+                    <tr>
+                        <th><?php _e('URL', 'suple-speed'); ?></th>
+                        <th><?php _e('Type', 'suple-speed'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($font_preloads as $preload): ?>
+                        <tr>
+                            <td><?php echo esc_html($preload['href'] ?? ''); ?></td>
+                            <td><?php echo esc_html($preload['type'] ?? ''); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <p><?php _e('No font preloads detected yet. Suple Speed will populate this list after scanning your pages.', 'suple-speed'); ?></p>
+        <?php endif; ?>
+    </div>
+</div>

--- a/views/admin-fonts.php
+++ b/views/admin-fonts.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Página de gestión de fuentes
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$fonts_module = function_exists('suple_speed') ? suple_speed()->fonts : null;
+$fonts_stats = [
+    'total_localized' => 0,
+    'total_size' => 0,
+    'total_size_formatted' => size_format(0),
+    'families' => [],
+    'files' => [],
+];
+
+if ($fonts_module && method_exists($fonts_module, 'get_fonts_stats')) {
+    $fonts_stats = $fonts_module->get_fonts_stats();
+    if (empty($fonts_stats['total_size_formatted'])) {
+        $fonts_stats['total_size_formatted'] = size_format((int) ($fonts_stats['total_size'] ?? 0));
+    }
+}
+?>
+
+<div class="suple-speed-admin">
+
+    <div class="suple-speed-header">
+        <h1><?php _e('Fonts', 'suple-speed'); ?></h1>
+        <p><?php _e('Localize Google Fonts and review font optimization status.', 'suple-speed'); ?></p>
+    </div>
+
+    <?php include SUPLE_SPEED_PLUGIN_DIR . 'views/partials/admin-nav.php'; ?>
+
+    <div class="suple-grid suple-grid-2 suple-mt-2">
+        <div class="suple-card">
+            <h3><?php _e('Localization Summary', 'suple-speed'); ?></h3>
+            <ul class="suple-stats">
+                <li class="suple-stat-card">
+                    <span class="suple-stat-value"><?php echo esc_html($fonts_stats['total_localized']); ?></span>
+                    <span class="suple-stat-label"><?php _e('Localized Fonts', 'suple-speed'); ?></span>
+                </li>
+                <li class="suple-stat-card">
+                    <span class="suple-stat-value"><?php echo esc_html($fonts_stats['total_size_formatted']); ?></span>
+                    <span class="suple-stat-label"><?php _e('Storage Used', 'suple-speed'); ?></span>
+                </li>
+            </ul>
+            <button type="button" class="suple-button suple-localize-fonts">
+                <span class="dashicons dashicons-admin-site-alt3"></span>
+                <?php _e('Localize Fonts Now', 'suple-speed'); ?>
+            </button>
+        </div>
+
+        <div class="suple-card">
+            <h3><?php _e('Font Families', 'suple-speed'); ?></h3>
+            <?php if (!empty($fonts_stats['families'])): ?>
+                <ul class="suple-list">
+                    <?php foreach ($fonts_stats['families'] as $family): ?>
+                        <li><?php echo esc_html($family); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php else: ?>
+                <p><?php _e('No localized font families detected yet.', 'suple-speed'); ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Localized Files', 'suple-speed'); ?></h3>
+        <?php if (!empty($fonts_stats['files'])): ?>
+            <table class="widefat">
+                <thead>
+                    <tr>
+                        <th><?php _e('File', 'suple-speed'); ?></th>
+                        <th><?php _e('Size', 'suple-speed'); ?></th>
+                        <th><?php _e('Last Modified', 'suple-speed'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($fonts_stats['files'] as $file): ?>
+                        <tr>
+                            <td><?php echo esc_html($file['name'] ?? ''); ?></td>
+                            <td><?php echo isset($file['size']) ? esc_html(size_format((int) $file['size'])) : ''; ?></td>
+                            <td><?php echo !empty($file['modified']) ? esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $file['modified'])) : ''; ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <p><?php _e('No font files have been localized yet. Run a localization to populate this list.', 'suple-speed'); ?></p>
+        <?php endif; ?>
+    </div>
+</div>

--- a/views/admin-images.php
+++ b/views/admin-images.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Página de optimización de imágenes
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$images_module = function_exists('suple_speed') ? suple_speed()->images : null;
+$image_stats = [
+    'total_images_processed' => 0,
+    'lazy_loading_applied' => 0,
+    'lqip_generated' => 0,
+    'webp_conversions' => 0,
+    'total_size_saved' => 0,
+];
+
+if ($images_module && method_exists($images_module, 'get_optimization_stats')) {
+    $image_stats = $images_module->get_optimization_stats();
+}
+
+$current_settings = $this->get_current_settings();
+?>
+
+<div class="suple-speed-admin">
+
+    <div class="suple-speed-header">
+        <h1><?php _e('Images', 'suple-speed'); ?></h1>
+        <p><?php _e('Control lazy loading, modern formats and LQIP generation.', 'suple-speed'); ?></p>
+    </div>
+
+    <?php include SUPLE_SPEED_PLUGIN_DIR . 'views/partials/admin-nav.php'; ?>
+
+    <div class="suple-grid suple-grid-2 suple-mt-2">
+        <div class="suple-card">
+            <h3><?php _e('Optimization Status', 'suple-speed'); ?></h3>
+            <ul class="suple-list">
+                <li>
+                    <strong><?php _e('Lazy Loading', 'suple-speed'); ?>:</strong>
+                    <span class="suple-badge <?php echo !empty($current_settings['images_lazy']) ? 'success' : 'error'; ?>">
+                        <?php echo !empty($current_settings['images_lazy']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                    </span>
+                </li>
+                <li>
+                    <strong><?php _e('LQIP Placeholders', 'suple-speed'); ?>:</strong>
+                    <?php echo !empty($current_settings['images_lqip']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                </li>
+                <li>
+                    <strong><?php _e('Modern Formats', 'suple-speed'); ?>:</strong>
+                    <?php echo !empty($current_settings['images_modern']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                </li>
+            </ul>
+
+            <a class="suple-button" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-images')); ?>">
+                <?php _e('Adjust Image Settings', 'suple-speed'); ?>
+            </a>
+        </div>
+
+        <div class="suple-card">
+            <h3><?php _e('Recent Activity', 'suple-speed'); ?></h3>
+            <ul class="suple-stats">
+                <li class="suple-stat-card">
+                    <span class="suple-stat-value"><?php echo esc_html($image_stats['lqip_generated']); ?></span>
+                    <span class="suple-stat-label"><?php _e('LQIPs Generated', 'suple-speed'); ?></span>
+                </li>
+                <li class="suple-stat-card">
+                    <span class="suple-stat-value"><?php echo esc_html($image_stats['webp_conversions']); ?></span>
+                    <span class="suple-stat-label"><?php _e('WebP Conversions', 'suple-speed'); ?></span>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Maintenance', 'suple-speed'); ?></h3>
+        <p><?php _e('Regenerate placeholders or clear cached data when necessary.', 'suple-speed'); ?></p>
+        <button type="button" class="suple-button suple-images-clear-lqip">
+            <span class="dashicons dashicons-image-rotate"></span>
+            <?php _e('Clear LQIP Cache', 'suple-speed'); ?>
+        </button>
+    </div>
+</div>

--- a/views/admin-logs.php
+++ b/views/admin-logs.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Página de registros
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$logger_module = function_exists('suple_speed') ? suple_speed()->logger : null;
+$log_stats = [
+    'total' => 0,
+    'by_level' => [],
+    'by_module' => [],
+];
+$recent_logs = [];
+
+if ($logger_module) {
+    if (method_exists($logger_module, 'get_log_stats')) {
+        $log_stats = $logger_module->get_log_stats();
+    }
+    if (method_exists($logger_module, 'get_logs')) {
+        $recent_logs = $logger_module->get_logs(20);
+    }
+}
+?>
+
+<div class="suple-speed-admin">
+
+    <div class="suple-speed-header">
+        <h1><?php _e('Logs', 'suple-speed'); ?></h1>
+        <p><?php _e('Review recent events recorded by Suple Speed.', 'suple-speed'); ?></p>
+    </div>
+
+    <?php include SUPLE_SPEED_PLUGIN_DIR . 'views/partials/admin-nav.php'; ?>
+
+    <div class="suple-grid suple-grid-3 suple-mt-2">
+        <div class="suple-stat-card">
+            <span class="suple-stat-value"><?php echo esc_html($log_stats['total'] ?? 0); ?></span>
+            <span class="suple-stat-label"><?php _e('Total Entries', 'suple-speed'); ?></span>
+        </div>
+        <?php if (!empty($log_stats['by_level'])): ?>
+            <?php foreach ($log_stats['by_level'] as $row): ?>
+                <div class="suple-stat-card">
+                    <span class="suple-stat-value"><?php echo esc_html($row->count); ?></span>
+                    <span class="suple-stat-label"><?php echo esc_html(ucfirst($row->level)); ?></span>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Recent Entries', 'suple-speed'); ?></h3>
+        <?php if (!empty($recent_logs)): ?>
+            <table class="widefat">
+                <thead>
+                    <tr>
+                        <th><?php _e('Date', 'suple-speed'); ?></th>
+                        <th><?php _e('Level', 'suple-speed'); ?></th>
+                        <th><?php _e('Module', 'suple-speed'); ?></th>
+                        <th><?php _e('Message', 'suple-speed'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($recent_logs as $log): ?>
+                        <tr>
+                            <td><?php echo !empty($log->timestamp) ? esc_html(mysql2date(get_option('date_format') . ' ' . get_option('time_format'), $log->timestamp)) : ''; ?></td>
+                            <td><?php echo esc_html(ucfirst($log->level ?? '')); ?></td>
+                            <td><?php echo esc_html($log->module ?? ''); ?></td>
+                            <td><?php echo esc_html($log->message ?? ''); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <p><?php _e('No log entries available yet.', 'suple-speed'); ?></p>
+        <?php endif; ?>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Actions', 'suple-speed'); ?></h3>
+        <div class="suple-button-group">
+            <button type="button" class="suple-button secondary suple-export-logs">
+                <?php _e('Export Logs', 'suple-speed'); ?>
+            </button>
+            <button type="button" class="suple-button suple-clear-logs">
+                <?php _e('Clear Logs', 'suple-speed'); ?>
+            </button>
+        </div>
+    </div>
+</div>

--- a/views/admin-performance.php
+++ b/views/admin-performance.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Página de rendimiento y PageSpeed Insights
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$psi_module = function_exists('suple_speed') ? suple_speed()->psi : null;
+$psi_stats = [
+    'total_tests' => 0,
+    'avg_performance_mobile' => 0,
+    'avg_performance_desktop' => 0,
+    'latest_test' => null,
+    'improvement_trend' => null,
+];
+
+if ($psi_module && method_exists($psi_module, 'get_psi_stats')) {
+    $psi_stats = $psi_module->get_psi_stats();
+}
+
+$psi_history = get_option('suple_speed_psi_history', []);
+$recent_tests = [];
+
+if (is_array($psi_history) && !empty($psi_history)) {
+    $recent_tests = array_slice(array_reverse($psi_history), 0, 5);
+}
+?>
+
+<div class="suple-speed-admin">
+
+    <div class="suple-speed-header">
+        <h1><?php _e('Performance', 'suple-speed'); ?></h1>
+        <p><?php _e('Monitor and launch PageSpeed Insights tests for your site.', 'suple-speed'); ?></p>
+    </div>
+
+    <?php include SUPLE_SPEED_PLUGIN_DIR . 'views/partials/admin-nav.php'; ?>
+
+    <div class="suple-grid suple-grid-2 suple-mt-2">
+        <div class="suple-card">
+            <h3><?php _e('Performance Overview', 'suple-speed'); ?></h3>
+
+            <div class="suple-stats">
+                <div class="suple-stat-card">
+                    <span class="suple-stat-value"><?php echo esc_html($psi_stats['total_tests']); ?></span>
+                    <span class="suple-stat-label"><?php _e('Total Tests', 'suple-speed'); ?></span>
+                </div>
+                <div class="suple-stat-card">
+                    <span class="suple-stat-value"><?php echo esc_html($psi_stats['avg_performance_mobile']); ?></span>
+                    <span class="suple-stat-label"><?php _e('Avg Mobile Score', 'suple-speed'); ?></span>
+                </div>
+                <div class="suple-stat-card">
+                    <span class="suple-stat-value"><?php echo esc_html($psi_stats['avg_performance_desktop']); ?></span>
+                    <span class="suple-stat-label"><?php _e('Avg Desktop Score', 'suple-speed'); ?></span>
+                </div>
+                <div class="suple-stat-card">
+                    <span class="suple-stat-value"><?php echo esc_html($psi_stats['improvement_trend'] ?? 0); ?></span>
+                    <span class="suple-stat-label"><?php _e('Trend (Mobile)', 'suple-speed'); ?></span>
+                </div>
+            </div>
+
+            <div class="suple-mt-2">
+                <button type="button" class="suple-button suple-run-psi" data-default-strategy="mobile">
+                    <span class="dashicons dashicons-performance"></span>
+                    <?php _e('Run PSI Test', 'suple-speed'); ?>
+                </button>
+                <a class="suple-button secondary" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-psi')); ?>">
+                    <?php _e('Configure API Key', 'suple-speed'); ?>
+                </a>
+            </div>
+        </div>
+
+        <div class="suple-card">
+            <h3><?php _e('Latest Test', 'suple-speed'); ?></h3>
+
+            <?php if (!empty($psi_stats['latest_test'])): ?>
+                <?php $latest = $psi_stats['latest_test']; ?>
+                <p><strong><?php _e('URL:', 'suple-speed'); ?></strong> <?php echo esc_html($latest['url'] ?? ''); ?></p>
+                <p><strong><?php _e('Strategy:', 'suple-speed'); ?></strong> <?php echo esc_html(ucfirst($latest['strategy'] ?? '')); ?></p>
+                <?php if (!empty($latest['scores']['performance']['score'])): ?>
+                    <p><strong><?php _e('Performance Score:', 'suple-speed'); ?></strong> <?php echo esc_html($latest['scores']['performance']['score']); ?></p>
+                <?php endif; ?>
+                <p><strong><?php _e('Tested At:', 'suple-speed'); ?></strong> <?php echo !empty($latest['timestamp']) ? esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $latest['timestamp'])) : ''; ?></p>
+            <?php else: ?>
+                <p><?php _e('No PageSpeed Insights tests have been run yet. Start one to populate this area.', 'suple-speed'); ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Recent Tests', 'suple-speed'); ?></h3>
+
+        <?php if (!empty($recent_tests)): ?>
+            <table class="widefat">
+                <thead>
+                    <tr>
+                        <th><?php _e('Date', 'suple-speed'); ?></th>
+                        <th><?php _e('URL', 'suple-speed'); ?></th>
+                        <th><?php _e('Strategy', 'suple-speed'); ?></th>
+                        <th><?php _e('Performance', 'suple-speed'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($recent_tests as $test): ?>
+                        <tr>
+                            <td><?php echo !empty($test['timestamp']) ? esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $test['timestamp'])) : ''; ?></td>
+                            <td><?php echo esc_html($test['url'] ?? ''); ?></td>
+                            <td><?php echo esc_html(ucfirst($test['strategy'] ?? '')); ?></td>
+                            <td><?php echo !empty($test['scores']['performance']['score']) ? esc_html($test['scores']['performance']['score']) : '&mdash;'; ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <p><?php _e('No previous tests recorded yet.', 'suple-speed'); ?></p>
+        <?php endif; ?>
+    </div>
+</div>

--- a/views/admin-rules.php
+++ b/views/admin-rules.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Página de reglas inteligentes
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$rules_module = function_exists('suple_speed') ? suple_speed()->rules : null;
+$rules = [];
+$rules_stats = [
+    'total_rules' => 0,
+    'enabled_rules' => 0,
+    'global_rules' => 0,
+    'url_rules' => 0,
+    'rules_by_type' => [],
+];
+
+if ($rules_module) {
+    if (method_exists($rules_module, 'get_all_rules')) {
+        $rules = $rules_module->get_all_rules();
+    }
+    if (method_exists($rules_module, 'get_rules_stats')) {
+        $rules_stats = $rules_module->get_rules_stats();
+    }
+}
+?>
+
+<div class="suple-speed-admin">
+
+    <div class="suple-speed-header">
+        <h1><?php _e('Rules', 'suple-speed'); ?></h1>
+        <p><?php _e('Fine tune caching and optimization behaviour based on flexible conditions.', 'suple-speed'); ?></p>
+    </div>
+
+    <?php include SUPLE_SPEED_PLUGIN_DIR . 'views/partials/admin-nav.php'; ?>
+
+    <div class="suple-grid suple-grid-3 suple-mt-2">
+        <div class="suple-stat-card">
+            <span class="suple-stat-value"><?php echo esc_html($rules_stats['total_rules']); ?></span>
+            <span class="suple-stat-label"><?php _e('Total Rules', 'suple-speed'); ?></span>
+        </div>
+        <div class="suple-stat-card">
+            <span class="suple-stat-value"><?php echo esc_html($rules_stats['enabled_rules']); ?></span>
+            <span class="suple-stat-label"><?php _e('Enabled', 'suple-speed'); ?></span>
+        </div>
+        <div class="suple-stat-card">
+            <span class="suple-stat-value"><?php echo esc_html($rules_stats['global_rules']); ?></span>
+            <span class="suple-stat-label"><?php _e('Global Rules', 'suple-speed'); ?></span>
+        </div>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Configured Rules', 'suple-speed'); ?></h3>
+
+        <?php if (!empty($rules)): ?>
+            <table class="widefat">
+                <thead>
+                    <tr>
+                        <th><?php _e('Name', 'suple-speed'); ?></th>
+                        <th><?php _e('Type', 'suple-speed'); ?></th>
+                        <th><?php _e('Scope', 'suple-speed'); ?></th>
+                        <th><?php _e('Status', 'suple-speed'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($rules as $rule_id => $rule): ?>
+                        <tr>
+                            <td><?php echo esc_html($rule['name'] ?? sprintf(__('Rule #%d', 'suple-speed'), $rule_id)); ?></td>
+                            <td><?php echo esc_html($rule['type'] ?? ''); ?></td>
+                            <td><?php echo esc_html($rule['scope'] ?? ''); ?></td>
+                            <td>
+                                <span class="suple-badge <?php echo !empty($rule['enabled']) ? 'success' : 'error'; ?>">
+                                    <?php echo !empty($rule['enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                                </span>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <p><?php _e('No rules configured yet. Use rules to conditionally enable caching, merging or exclusions.', 'suple-speed'); ?></p>
+        <?php endif; ?>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Create or Import Rules', 'suple-speed'); ?></h3>
+        <p><?php _e('Set up custom rules or import existing configurations to tailor the optimisation behaviour.', 'suple-speed'); ?></p>
+        <div class="suple-button-group">
+            <a class="suple-button" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-advanced')); ?>">
+                <?php _e('Open Rule Builder', 'suple-speed'); ?>
+            </a>
+            <button type="button" class="suple-button secondary suple-import-rules">
+                <?php _e('Import Rules', 'suple-speed'); ?>
+            </button>
+        </div>
+    </div>
+</div>

--- a/views/admin-tools.php
+++ b/views/admin-tools.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Página de herramientas
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$cache_module = function_exists('suple_speed') ? suple_speed()->cache : null;
+$logger_module = function_exists('suple_speed') ? suple_speed()->logger : null;
+
+$cache_stats = [
+    'total_files' => 0,
+    'total_size_formatted' => size_format(0),
+];
+
+if ($cache_module && method_exists($cache_module, 'get_cache_stats')) {
+    $cache_stats = $cache_module->get_cache_stats();
+    if (empty($cache_stats['total_size_formatted'])) {
+        $cache_stats['total_size_formatted'] = size_format((int) ($cache_stats['total_size'] ?? 0));
+    }
+}
+
+$log_stats = [
+    'total' => 0,
+    'by_level' => [],
+];
+
+if ($logger_module && method_exists($logger_module, 'get_log_stats')) {
+    $log_stats = $logger_module->get_log_stats();
+}
+?>
+
+<div class="suple-speed-admin">
+
+    <div class="suple-speed-header">
+        <h1><?php _e('Tools', 'suple-speed'); ?></h1>
+        <p><?php _e('Utility actions to debug and maintain Suple Speed.', 'suple-speed'); ?></p>
+    </div>
+
+    <?php include SUPLE_SPEED_PLUGIN_DIR . 'views/partials/admin-nav.php'; ?>
+
+    <div class="suple-grid suple-grid-2 suple-mt-2">
+        <div class="suple-card">
+            <h3><?php _e('Cache Maintenance', 'suple-speed'); ?></h3>
+            <p><?php _e('Review current cache footprint and purge it on demand.', 'suple-speed'); ?></p>
+            <ul class="suple-list">
+                <li>
+                    <strong><?php _e('Cached Files', 'suple-speed'); ?>:</strong> <?php echo esc_html($cache_stats['total_files'] ?? 0); ?>
+                </li>
+                <li>
+                    <strong><?php _e('Disk Usage', 'suple-speed'); ?>:</strong> <?php echo esc_html($cache_stats['total_size_formatted'] ?? size_format(0)); ?>
+                </li>
+            </ul>
+            <div class="suple-button-group">
+                <button type="button" class="suple-button suple-purge-cache" data-purge-action="all">
+                    <?php _e('Purge Cache', 'suple-speed'); ?>
+                </button>
+                <button type="button" class="suple-button secondary suple-purge-cache" data-purge-action="expired">
+                    <?php _e('Clean Expired', 'suple-speed'); ?>
+                </button>
+            </div>
+        </div>
+
+        <div class="suple-card">
+            <h3><?php _e('Logs Overview', 'suple-speed'); ?></h3>
+            <p><?php _e('Inspect recent log volume before exporting or clearing data.', 'suple-speed'); ?></p>
+            <p><strong><?php _e('Entries Stored', 'suple-speed'); ?>:</strong> <?php echo esc_html($log_stats['total'] ?? 0); ?></p>
+            <?php if (!empty($log_stats['by_level'])): ?>
+                <ul class="suple-list">
+                    <?php foreach ($log_stats['by_level'] as $row): ?>
+                        <li><?php echo esc_html(sprintf('%s: %d', ucfirst($row->level), $row->count)); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+            <div class="suple-button-group">
+                <button type="button" class="suple-button secondary suple-export-logs">
+                    <?php _e('Export Logs', 'suple-speed'); ?>
+                </button>
+                <button type="button" class="suple-button suple-clear-logs">
+                    <?php _e('Clear Logs', 'suple-speed'); ?>
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div class="suple-card suple-mt-2">
+        <h3><?php _e('Diagnostics', 'suple-speed'); ?></h3>
+        <p><?php _e('Use these helpers to verify that core services are working as expected.', 'suple-speed'); ?></p>
+        <div class="suple-button-group">
+            <button type="button" class="suple-button suple-run-psi" data-default-strategy="mobile">
+                <?php _e('Run PSI Test', 'suple-speed'); ?>
+            </button>
+            <button type="button" class="suple-button secondary suple-test-cache">
+                <?php _e('Test Cache Warmup', 'suple-speed'); ?>
+            </button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add performance, cache, and assets admin templates wired to Suple Speed modules for basic stats and actions
- provide critical CSS, fonts, images, rules, compatibility, tools, and logs views that surface module data with placeholder layouts

## Testing
- php -l views/admin-*.php

------
https://chatgpt.com/codex/tasks/task_e_68cbfa75769c8330a21df27aa34c5189