### PR TITLE
Improve admin auto-save handling

### DIFF
--- a/views/admin-settings.php
+++ b/views/admin-settings.php
@@ -530,4 +530,8 @@ $current_settings = $this->get_current_settings();
 .suple-auto-save-indicator.success {
     background: var(--suple-success);
 }
+
+.suple-auto-save-indicator.error {
+    background: var(--suple-error);
+}
 </style>


### PR DESCRIPTION
## Summary
- make the admin auto-save collect form values and persist them through the existing save_settings AJAX endpoint
- gate auto-save setup behind an optional flag, clean up timers when disabled, and reuse a shared status indicator that reports success or failure
- style the indicator error state so failed auto-saves are obvious while also surfacing the standard error notice

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cbfa83792483309531429464a5cc73