### PR TITLE
Limit font buffering to wp_head

### DIFF
--- a/includes/class-fonts.php
+++ b/includes/class-fonts.php
@@ -14,6 +14,7 @@ class Fonts {
     private $logger;
     private $fonts_dir;
     private $fonts_url;
+    private $capturing_head = false;
     
     /**
      * Fuentes detectadas
@@ -40,7 +41,7 @@ class Fonts {
         if ($this->settings['fonts_local']) {
             // Capturar y procesar fuentes en el frontend
             add_action('wp_head', [$this, 'capture_google_fonts'], 1);
-            add_action('wp_footer', [$this, 'inject_local_fonts'], 999);
+            add_action('wp_head', [$this, 'inject_local_fonts'], PHP_INT_MAX);
             
             // Filtrar URLs de Google Fonts
             add_filter('style_loader_src', [$this, 'filter_google_fonts_url'], 10, 2);
@@ -58,19 +59,29 @@ class Fonts {
      * Capturar Google Fonts del HTML
      */
     public function capture_google_fonts() {
+        if ($this->capturing_head) {
+            return;
+        }
+
+        $this->capturing_head = true;
         ob_start();
     }
-    
+
     /**
      * Inyectar fuentes locales
      */
     public function inject_local_fonts() {
+        if (!$this->capturing_head) {
+            return;
+        }
+
         $buffer = ob_get_clean();
-        
+        $this->capturing_head = false;
+
         if (!empty($buffer)) {
             $buffer = $this->process_google_fonts_in_html($buffer);
         }
-        
+
         echo $buffer;
     }
     


### PR DESCRIPTION
## Summary
- track whether the fonts class is capturing wp_head output
- limit the Google Fonts buffering lifecycle to wp_head so the buffer is always released
- keep processing of the captured HTML while avoiding global output buffering

## Testing
- php -l includes/class-fonts.php

------
https://chatgpt.com/codex/tasks/task_e_68cc0759c5248330a300c8ba677ce115