### PR TITLE
Add fallback cache headers for static resources

### DIFF
--- a/views/admin-settings.php
+++ b/views/admin-settings.php
@@ -134,6 +134,8 @@ $current_settings = $this->get_current_settings();
                                min="1" max="168" class="suple-form-input">
                         <div class="suple-form-help">
                             <?php _e('How long to keep cached pages before regenerating them.', 'suple-speed'); ?>
+                            <br>
+                            <?php _e('When server rules cannot be written, Suple Speed will automatically apply Cache-Control, Expires and ETag headers to local static files using this lifetime as fallback.', 'suple-speed'); ?>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- register a wp_headers filter to inject cache headers when static assets are served via PHP
- add detection for local static resources and avoid duplicating headers already set by the server
- document the automatic fallback headers in the cache lifetime setting help text

## Testing
- php -l includes/class-cache.php
- php -l views/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68ccfa4efcd88330907d68fc0322336b