### PR TITLE
Add async CSS preload support with admin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,3 +375,14 @@ Desarrollado por **Suple** - Especialistas en optimización de WordPress y Eleme
 ---
 
 **¿Te gusta Suple Speed?** ⭐ [Danos una calificación](https://wordpress.org/plugins/suple-speed/) y comparte con otros desarrolladores.
+
+# 🧪 Pruebas Manuales Guiadas
+
+## Validar carga asíncrona de CSS fusionado
+1. Activa la fusión de CSS y selecciona los grupos que quieras marcar como "Async CSS Groups" en `Suple Speed > Settings > Advanced`.
+2. Purga la caché de Suple Speed y la del navegador para comenzar desde un estado limpio.
+3. Abre en el frontend una página construida con Elementor que incluya widgets globales, plantillas y tipografías personalizadas.
+4. Comprueba en las herramientas de desarrollador (pestaña Network) que los archivos `suple-speed-css-*` se solicitan como `rel=preload`, cambian a `rel=stylesheet` tras cargarse y no generan errores 404.
+5. Repite la verificación dentro del editor de Elementor para confirmar que las dependencias de estilo (Elementor Kit, tipografías y efectos) se mantienen intactas.
+6. Si detectas cualquier FOUC, marca el grupo afectado como crítico (sin async) y vuelve a probar tras limpiar caché.
+

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -253,6 +253,7 @@ class Admin {
         $array_settings = [
             'cache_exclude_params', 'assets_exclude_handles', 
             'assets_no_defer_handles', 'assets_merge_css_groups',
+            'assets_async_css_groups',
             'assets_merge_js_groups', 'cache_vary_cookies',
             'assets_test_roles', 'assets_test_ips', 'preload_assets',
             'fonts_preload', 'images_preload'
@@ -262,8 +263,15 @@ class Admin {
             $sanitized[$setting] = isset($input[$setting]) && is_array($input[$setting]) ?
                                    array_map('sanitize_text_field', $input[$setting]) :
                                    [];
+
+            if ($setting === 'assets_async_css_groups') {
+                $sanitized[$setting] = array_values(array_unique(array_intersect(
+                    ['A', 'B', 'C', 'D'],
+                    array_map('strtoupper', $sanitized[$setting])
+                )));
+            }
         }
-        
+
         return $sanitized;
     }
     

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -31,6 +31,8 @@ class Assets {
     private $processed_handles = [];
     private $excluded_handles = [];
     private $dependency_map = [];
+    private $async_css_groups = [];
+    private $style_filter_registered = false;
     
     public function __construct() {
         $this->settings = get_option('suple_speed_settings', []);
@@ -40,7 +42,9 @@ class Assets {
         if (function_exists('suple_speed')) {
             $this->logger = suple_speed()->logger;
         }
-        
+
+        $this->async_css_groups = array_map('strtoupper', $this->settings['assets_async_css_groups'] ?? []);
+
         $this->init_hooks();
         $this->load_excluded_handles();
     }
@@ -52,7 +56,7 @@ class Assets {
         // Solo en frontend y fuera del editor de Elementor
         if (!is_admin() && !$this->is_editor_mode()) {
             add_action('wp_enqueue_scripts', [$this, 'optimize_scripts_styles'], 999);
-            add_action('wp_head', [$this, 'inject_critical_css'], 1);
+            add_action('wp_head', [$this, 'inject_critical_css'], 0);
             add_action('wp_head', [$this, 'inject_preloads'], 2);
             
             // Filtros para modificar output
@@ -391,7 +395,15 @@ class Assets {
                     [],
                     $merged_file['version']
                 );
+
+                if (!empty($this->async_css_groups)) {
+                    $this->ensure_async_style_filter();
+                }
             }
+        }
+
+        if (!empty($this->async_css_groups)) {
+            $this->log_async_manual_tests();
         }
     }
     
@@ -945,15 +957,106 @@ class Assets {
             'url' => $this->get_current_url(),
             'post_id' => get_the_ID()
         ]);
-        
+
         // Si no hay CSS específico, usar el general
         if (empty($critical_css)) {
             $critical_css = $this->settings['critical_css_general'] ?? '';
         }
-        
+
         return $critical_css;
     }
-    
+
+    /**
+     * Registrar filtro para precarga de estilos
+     */
+    private function ensure_async_style_filter() {
+        if ($this->style_filter_registered) {
+            return;
+        }
+
+        add_filter('style_loader_tag', [$this, 'filter_style_loader_tag'], 10, 4);
+        $this->style_filter_registered = true;
+    }
+
+    /**
+     * Convertir enlaces de estilos en precarga asincrónica
+     */
+    public function filter_style_loader_tag($html, $handle, $href, $media) {
+        if (empty($this->async_css_groups) || empty($href)) {
+            return $html;
+        }
+
+        if (in_array($handle, $this->excluded_handles, true)) {
+            return $html;
+        }
+
+        $group = $this->get_group_from_handle($handle);
+
+        if (!$group || !in_array($group, $this->async_css_groups, true)) {
+            return $html;
+        }
+
+        $this->log_async_manual_tests();
+
+        $media_attr = '';
+        if (!empty($media) && $media !== 'all') {
+            $media_attr = ' media="' . esc_attr($media) . '"';
+        }
+
+        $id_attr = ' id="' . esc_attr($handle) . '-css"';
+        $preload_tag = '<link rel="preload" as="style" href="' . esc_url($href) . '"' . $id_attr . $media_attr . ' onload="this.rel=\'stylesheet\';this.removeAttribute(\'onload\');">';
+        $noscript_tag = '<noscript><link rel="stylesheet" href="' . esc_url($href) . '"' . $id_attr . $media_attr . '></noscript>';
+
+        return $preload_tag . "\n" . $noscript_tag;
+    }
+
+    /**
+     * Obtener grupo a partir del handle fusionado
+     */
+    private function get_group_from_handle($handle) {
+        if (strpos($handle, 'suple-speed-css-') !== 0) {
+            return null;
+        }
+
+        $suffix = strtoupper(str_replace('suple-speed-css-', '', $handle));
+
+        if (strlen($suffix) !== 1) {
+            return null;
+        }
+
+        return $suffix;
+    }
+
+    /**
+     * Registrar en el logger las pruebas manuales
+     */
+    private function log_async_manual_tests() {
+        if (!$this->logger) {
+            return;
+        }
+
+        static $logged = false;
+
+        if ($logged) {
+            return;
+        }
+
+        $logged = true;
+
+        if (empty($this->async_css_groups)) {
+            return;
+        }
+
+        $this->logger->notice('Manual test required: validate Elementor CSS dependencies with async loading.', [
+            'async_css_groups' => $this->async_css_groups,
+            'steps' => [
+                '1. Clear caches and load a complex Elementor page on the frontend to ensure widgets render styled.',
+                '2. Open the same page in the Elementor editor and verify that the design system and global styles load without delays.',
+                '3. Inspect the Network tab to confirm suple-speed-css-* requests complete and rel="stylesheet" is applied after preload.'
+            ]
+        ]);
+    }
+
     /**
      * Inyectar preloads
      */

--- a/views/admin-settings.php
+++ b/views/admin-settings.php
@@ -422,11 +422,11 @@ $current_settings = $this->get_current_settings();
                             <?php
                             $css_groups = ['A' => 'Core & Theme', 'B' => 'Plugins', 'C' => 'Elementor', 'D' => 'Third Party'];
                             $selected_css_groups = $current_settings['assets_merge_css_groups'] ?? ['A', 'B'];
-                            
+
                             foreach ($css_groups as $group => $label):
                             ?>
                             <label class="suple-form-toggle">
-                                <input type="checkbox" name="assets_merge_css_groups[]" value="<?php echo esc_attr($group); ?>" 
+                                <input type="checkbox" name="assets_merge_css_groups[]" value="<?php echo esc_attr($group); ?>"
                                        <?php checked(in_array($group, $selected_css_groups)); ?>>
                                 <span><?php printf(__('Group %s: %s', 'suple-speed'), $group, $label); ?></span>
                             </label>
@@ -434,6 +434,27 @@ $current_settings = $this->get_current_settings();
                         </div>
                         <div class="suple-form-help">
                             <?php _e('Select which asset groups to merge together. Group C (Elementor) should be handled carefully.', 'suple-speed'); ?>
+                        </div>
+                    </div>
+
+                    <!-- Asynchronous CSS Groups -->
+                    <div class="suple-form-row">
+                        <label class="suple-form-label"><?php _e('Async CSS Groups', 'suple-speed'); ?></label>
+                        <div class="suple-checkbox-group">
+                            <?php
+                            $async_css_groups = $current_settings['assets_async_css_groups'] ?? [];
+
+                            foreach ($css_groups as $group => $label):
+                            ?>
+                            <label class="suple-form-toggle">
+                                <input type="checkbox" name="assets_async_css_groups[]" value="<?php echo esc_attr($group); ?>"
+                                       <?php checked(in_array($group, $async_css_groups)); ?>>
+                                <span><?php printf(__('Load Group %s (%s) asynchronously', 'suple-speed'), $group, $label); ?></span>
+                            </label>
+                            <?php endforeach; ?>
+                        </div>
+                        <div class="suple-form-help">
+                            <?php _e('Selected groups will use <link rel="preload"> + onload to avoid render blocking. Leave critical groups unchecked.', 'suple-speed'); ?>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- convert merged CSS handles into preload/onload markup with noscript fallback and keep critical CSS inline ahead of async links
- add settings controls and sanitization for selecting which CSS groups load asynchronously and log manual Elementor verification steps
- document the guided manual test plan for async CSS validation

## Testing
- php -l includes/class-assets.php
- php -l includes/class-admin.php
- php -l views/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68ccfa50809c83308d21f83adc4199a5