### PR TITLE
Ensure local fonts use font-display swap

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -216,7 +216,7 @@ class Admin {
         $boolean_settings = [
             'cache_enabled', 'compression_enabled', 'assets_enabled',
             'merge_css', 'merge_js', 'minify_css', 'minify_js', 'defer_js',
-            'critical_css_enabled', 'fonts_local', 'images_lazy', 'images_lqip',
+            'critical_css_enabled', 'fonts_local', 'fonts_display_swap', 'images_lazy', 'images_lqip',
             'images_webp_rewrite', 'elementor_compat', 'safe_mode',
             'multisite_network', 'assets_test_mode', 'psi_auto_test'
         ];

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -440,10 +440,25 @@ class Assets {
         if (!empty($merged_content)) {
             // Optimizaciones finales
             $merged_content = $this->optimize_final_css($merged_content);
-            
+
+            if (function_exists('suple_speed')) {
+                $fonts_module = suple_speed()->fonts ?? null;
+
+                if ($fonts_module && method_exists($fonts_module, 'enforce_font_display_swap')) {
+                    $result = $fonts_module->enforce_font_display_swap(
+                        $merged_content,
+                        'merged_css_' . strtolower($group)
+                    );
+
+                    if (is_array($result) && isset($result['css'])) {
+                        $merged_content = $result['css'];
+                    }
+                }
+            }
+
             // Guardar archivo
             $bytes_written = file_put_contents($merged_file, $merged_content);
-            
+
             if ($bytes_written !== false) {
                 // Guardar metadatos
                 $this->save_merge_metadata($merged_file, [

--- a/views/admin-settings.php
+++ b/views/admin-settings.php
@@ -303,12 +303,26 @@ $current_settings = $this->get_current_settings();
                         </div>
                     </div>
 
+                    <!-- Font Display Swap -->
+                    <div class="suple-form-row">
+                        <div class="suple-form-toggle">
+                            <div class="suple-toggle">
+                                <input type="checkbox" id="fonts_display_swap" name="fonts_display_swap" <?php checked($current_settings['fonts_display_swap'] ?? true); ?>>
+                                <span class="suple-toggle-slider"></span>
+                            </div>
+                            <label for="fonts_display_swap" class="suple-form-label"><?php _e('Add font-display: swap to local fonts', 'suple-speed'); ?></label>
+                        </div>
+                        <div class="suple-form-help">
+                            <?php _e('Automatically append font-display: swap to @font-face rules that serve fonts from your domain. Disable if this conflicts with custom styling.', 'suple-speed'); ?>
+                        </div>
+                    </div>
+
                     <!-- Font Display -->
                     <div class="suple-form-row">
                         <div class="suple-notice info">
                             <p>
                                 <strong><?php _e('Font Display Optimization', 'suple-speed'); ?></strong><br>
-                                <?php _e('Suple Speed automatically adds font-display: swap to all fonts for better loading performance.', 'suple-speed'); ?>
+                                <?php _e('Ensures text stays visible while local webfonts load by leveraging the font-display property.', 'suple-speed'); ?>
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- add a toggle to control whether local @font-face rules receive font-display: swap and document it in settings
- share a font-display enforcement routine across merged CSS and inline styles, logging the number of adjusted blocks
- hook the shared routine into CSS merging so local fonts gain font-display while respecting existing declarations

## Testing
- php -l includes/class-admin.php
- php -l includes/class-fonts.php
- php -l includes/class-assets.php
- php -l views/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68ccfa54cdac83308e7b5efd6466bd5f