### PR TITLE
Improve boolean sanitization for admin settings

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -222,7 +222,9 @@ class Admin {
         ];
         
         foreach ($boolean_settings as $setting) {
-            $sanitized[$setting] = !empty($input[$setting]);
+            $sanitized[$setting] = array_key_exists($setting, $input)
+                ? filter_var($input[$setting], FILTER_VALIDATE_BOOLEAN)
+                : false;
         }
         
         // Configuraciones numéricas


### PR DESCRIPTION
## Summary
- ensure boolean settings default to false when missing during sanitization
- use FILTER_VALIDATE_BOOLEAN so string values like "false" or "0" are treated as false

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cd13d98ca48330ba23bfbbca2d38b3