### PR TITLE
Store cache TTL in seconds

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -253,8 +253,15 @@ class Admin {
         ];
         
         foreach ($numeric_settings as $setting => $default) {
-            $sanitized[$setting] = isset($input[$setting]) ? 
-                                   intval($input[$setting]) : 
+            if ($setting === 'cache_ttl') {
+                $sanitized[$setting] = isset($input[$setting])
+                    ? intval($input[$setting]) * HOUR_IN_SECONDS
+                    : $default;
+                continue;
+            }
+
+            $sanitized[$setting] = isset($input[$setting]) ?
+                                   intval($input[$setting]) :
                                    $default;
         }
         


### PR DESCRIPTION
## Summary
- ensure `cache_ttl` is stored in seconds by multiplying the submitted value by `HOUR_IN_SECONDS`
- keep the existing default TTL and UI display logic unchanged

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cd243f62f483308e215a1b7448a564