### PR TITLE
Expose default options reset helper

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -712,7 +712,7 @@ class Admin {
         
         // Recrear configuración por defecto
         if (function_exists('suple_speed')) {
-            suple_speed()->set_default_options();
+            suple_speed()->reset_default_options();
         }
         
         wp_send_json_success([

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -725,7 +725,7 @@ class WP_CLI {
         
         // Recrear configuraciones por defecto
         if (function_exists('suple_speed')) {
-            suple_speed()->set_default_options();
+            suple_speed()->reset_default_options();
         }
         
         \WP_CLI::success('Settings reset to defaults');

--- a/suple-speed.php
+++ b/suple-speed.php
@@ -430,6 +430,13 @@ class SupleSpeed {
         add_option('suple_speed_rules', []);
         add_option('suple_speed_onboarding', []);
     }
+
+    /**
+     * Permite recrear las opciones por defecto desde otros componentes.
+     */
+    public function reset_default_options() {
+        $this->set_default_options();
+    }
     
     /**
      * Generar reglas de servidor


### PR DESCRIPTION
## Summary
- add a public reset_default_options() helper to recreate the plugin defaults
- update admin ajax and WP-CLI reset flows to rely on the new helper

## Testing
- php -l suple-speed.php
- php -l includes/class-admin.php
- php -l includes/class-wp-cli.php

------
https://chatgpt.com/codex/tasks/task_e_68cd3fd2bbb88330aa9544ddf3ceb193