### PR TITLE
Clean onboarding state during uninstall

### DIFF
--- a/suple-speed.php
+++ b/suple-speed.php
@@ -331,12 +331,29 @@ class SupleSpeed {
     public static function uninstall() {
         // Limpiar opciones
         delete_option('suple_speed_settings');
+        global $wpdb;
+
         delete_option('suple_speed_rules');
         delete_option('suple_speed_psi_data');
         delete_option('suple_speed_version');
-        
+        delete_option('suple_speed_onboarding');
+
+        // Limpiar cualquier otro estado de onboarding almacenado
+        $onboarding_like = $wpdb->esc_like('suple_speed_onboarding_') . '%';
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+                $onboarding_like
+            )
+        );
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE %s",
+                $onboarding_like
+            )
+        );
+
         // Limpiar transients
-        global $wpdb;
         $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_suple_speed_%'");
         $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_suple_speed_%'");
         


### PR DESCRIPTION
## Summary
- ensure uninstall removes the onboarding option and any related onboarding state
- clear onboarding-related option and user meta records that may have been created during usage

## Testing
- not run (WordPress environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd3fd3c4a08330921cb2d534506b60