### PR TITLE
Add onboarding dismiss toggle for admin dashboard

### DIFF
--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -520,6 +520,98 @@
     display: block;
 }
 
+/* === ONBOARDING === */
+.suple-onboarding {
+    position: relative;
+}
+
+.suple-onboarding-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.suple-onboarding-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.suple-onboarding-progress-count {
+    font-weight: 600;
+    color: var(--suple-text-light);
+}
+
+.suple-onboarding-actions {
+    display: flex;
+    gap: 8px;
+    margin-left: auto;
+}
+
+.suple-onboarding-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    font-size: 13px;
+    line-height: 1.4;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--suple-radius);
+    color: var(--suple-text-light);
+    cursor: pointer;
+}
+
+.suple-onboarding-toggle .dashicons {
+    font-size: 16px;
+    line-height: 1;
+}
+
+.suple-onboarding-toggle:hover,
+.suple-onboarding-toggle:focus {
+    color: var(--suple-text);
+    border-color: var(--suple-border);
+    background: var(--suple-bg-light);
+}
+
+.suple-onboarding-toggle:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px rgba(19, 94, 150, 0.35);
+}
+
+.suple-onboarding-reopen {
+    display: none;
+}
+
+.suple-onboarding-collapsed-message {
+    display: none;
+    margin: 0 0 16px 0;
+    font-size: 13px;
+    color: var(--suple-text-light);
+}
+
+.suple-onboarding-body {
+    transition: opacity 0.2s ease;
+}
+
+.suple-onboarding.is-dismissed .suple-onboarding-body {
+    display: none;
+}
+
+.suple-onboarding.is-dismissed .suple-onboarding-collapsed-message {
+    display: block;
+}
+
+.suple-onboarding.is-dismissed .suple-onboarding-reopen {
+    display: inline-flex;
+}
+
+.suple-onboarding.is-dismissed .suple-onboarding-dismiss {
+    display: none;
+}
+
 /* === DASHBOARD ESPECÍFICO === */
 .suple-dashboard-welcome {
     background: linear-gradient(135deg, var(--suple-primary) 0%, var(--suple-primary-dark) 100%);

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1460,6 +1460,46 @@
                     SupleSpeedAdmin.showNotice('error', errorMessage);
                 });
             });
+
+            $(document).on('click', '.suple-onboarding-dismiss', function(e) {
+                e.preventDefault();
+
+                const $button = $(this);
+                if ($button.prop('disabled')) {
+                    return;
+                }
+
+                const $container = $button.closest('.suple-onboarding');
+                if ($container.length === 0) {
+                    return;
+                }
+
+                SupleSpeedAdmin.updateOnboardingDismissed($container, true);
+            });
+
+            $(document).on('click', '.suple-onboarding-reopen', function(e) {
+                e.preventDefault();
+
+                const $button = $(this);
+                if ($button.prop('disabled')) {
+                    return;
+                }
+
+                const $container = $button.closest('.suple-onboarding');
+                if ($container.length === 0) {
+                    return;
+                }
+
+                SupleSpeedAdmin.updateOnboardingDismissed($container, false);
+            });
+
+            $guide.each(function() {
+                const $container = $(this);
+                const dismissedAttr = $container.attr('data-dismissed');
+                const isDismissed = dismissedAttr === '1' || dismissedAttr === 1 || dismissedAttr === true;
+
+                SupleSpeedAdmin.applyOnboardingState($container, isDismissed);
+            });
         },
 
         updateOnboardingProgress: function($container, data) {
@@ -1506,6 +1546,65 @@
                     const successText = $status.data('success-text') || '';
                     $status.removeClass('warning').addClass('success').text(successText);
                 }
+            }
+
+            if (typeof data.dismissed !== 'undefined') {
+                const isDismissed = data.dismissed === true || data.dismissed === 1 || data.dismissed === '1';
+                SupleSpeedAdmin.applyOnboardingState($container, isDismissed);
+            }
+        },
+
+        updateOnboardingDismissed: function($container, dismissed) {
+            if (!$container || $container.length === 0) {
+                return;
+            }
+
+            const $buttons = $container.find('.suple-onboarding-dismiss, .suple-onboarding-reopen');
+            $buttons.prop('disabled', true);
+
+            SupleSpeedAdmin.ajaxRequest('update_onboarding', {
+                dismissed: dismissed ? 1 : 0
+            }, function(data) {
+                $buttons.prop('disabled', false);
+
+                if (data) {
+                    SupleSpeedAdmin.updateOnboardingProgress($container, data);
+                }
+            }, function(error) {
+                $buttons.prop('disabled', false);
+
+                const errorMessage = (error && error.message)
+                    ? error.message
+                    : (typeof error === 'string' && error)
+                        ? error
+                        : (supleSpeedAdmin.strings && supleSpeedAdmin.strings.error) || 'An error occurred';
+
+                SupleSpeedAdmin.showNotice('error', errorMessage);
+            });
+        },
+
+        applyOnboardingState: function($container, dismissed) {
+            if (!$container || $container.length === 0) {
+                return;
+            }
+
+            const isDismissed = dismissed === true || dismissed === 1 || dismissed === '1';
+            $container.toggleClass('is-dismissed', isDismissed);
+            $container.attr('data-dismissed', isDismissed ? '1' : '0');
+
+            const $body = $container.find('.suple-onboarding-body');
+            if ($body.length) {
+                $body.attr('aria-hidden', isDismissed ? 'true' : 'false');
+            }
+
+            const $dismissButton = $container.find('.suple-onboarding-dismiss');
+            if ($dismissButton.length) {
+                $dismissButton.attr('aria-expanded', isDismissed ? 'false' : 'true');
+            }
+
+            const $reopenButton = $container.find('.suple-onboarding-reopen');
+            if ($reopenButton.length) {
+                $reopenButton.attr('aria-expanded', isDismissed ? 'false' : 'true');
             }
         },
 

--- a/views/admin-dashboard.php
+++ b/views/admin-dashboard.php
@@ -199,6 +199,9 @@ if (!is_array($onboarding_state)) {
     $onboarding_state = [];
 }
 
+$onboarding_dismissed = !empty($onboarding_state['dismissed']);
+$onboarding_body_id   = 'suple-onboarding-body-' . uniqid();
+
 $onboarding_total = count($onboarding_steps);
 $onboarding_completed = 0;
 
@@ -251,36 +254,62 @@ $onboarding_critical_labels = array_map(function($step) {
 
     <!-- Getting Started -->
     <?php if ($onboarding_total > 0): ?>
-    <div class="suple-card suple-onboarding" data-total="<?php echo esc_attr($onboarding_total); ?>" data-completed="<?php echo esc_attr($onboarding_completed); ?>">
+    <div class="suple-card suple-onboarding <?php echo $onboarding_dismissed ? 'is-dismissed' : ''; ?>"
+         data-total="<?php echo esc_attr($onboarding_total); ?>"
+         data-completed="<?php echo esc_attr($onboarding_completed); ?>"
+         data-dismissed="<?php echo $onboarding_dismissed ? '1' : '0'; ?>">
         <div class="suple-onboarding-head">
-            <h3><?php _e('Guía rápida', 'suple-speed'); ?></h3>
-            <span class="suple-onboarding-progress-count"><?php echo esc_html(sprintf('%d/%d', $onboarding_completed, $onboarding_total)); ?></span>
-        </div>
-
-        <div class="suple-onboarding-progress">
-            <div class="suple-onboarding-progress-bar">
-                <span class="suple-onboarding-progress-bar-fill" style="width: <?php echo esc_attr($onboarding_progress); ?>%;"></span>
+            <div class="suple-onboarding-title">
+                <h3><?php _e('Guía rápida', 'suple-speed'); ?></h3>
+                <span class="suple-onboarding-progress-count"><?php echo esc_html(sprintf('%d/%d', $onboarding_completed, $onboarding_total)); ?></span>
             </div>
-            <span class="suple-onboarding-progress-label"><?php echo esc_html($onboarding_progress); ?>%</span>
+            <div class="suple-onboarding-actions">
+                <button type="button"
+                        class="suple-onboarding-toggle suple-onboarding-dismiss"
+                        aria-controls="<?php echo esc_attr($onboarding_body_id); ?>"
+                        aria-expanded="<?php echo $onboarding_dismissed ? 'false' : 'true'; ?>">
+                    <span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
+                    <span><?php _e('Ocultar', 'suple-speed'); ?></span>
+                </button>
+                <button type="button"
+                        class="suple-onboarding-toggle suple-onboarding-reopen"
+                        aria-controls="<?php echo esc_attr($onboarding_body_id); ?>"
+                        aria-expanded="<?php echo $onboarding_dismissed ? 'false' : 'true'; ?>">
+                    <span class="dashicons dashicons-visibility" aria-hidden="true"></span>
+                    <span><?php _e('Mostrar', 'suple-speed'); ?></span>
+                </button>
+            </div>
         </div>
 
-        <p class="suple-onboarding-status <?php echo empty($onboarding_critical_remaining) ? 'success' : 'warning'; ?>"
-           data-warning-template="<?php echo esc_attr__('Quedan %1$s pasos críticos por completar: %2$s', 'suple-speed'); ?>"
-           data-success-text="<?php echo esc_attr__('¡Listo! Todas las optimizaciones críticas están activas.', 'suple-speed'); ?>">
-            <?php if (empty($onboarding_critical_remaining)): ?>
-                <?php _e('¡Listo! Todas las optimizaciones críticas están activas.', 'suple-speed'); ?>
-            <?php else: ?>
-                <?php
-                printf(
-                    esc_html__('Quedan %1$s pasos críticos por completar: %2$s', 'suple-speed'),
-                    count($onboarding_critical_remaining),
-                    esc_html(implode(', ', $onboarding_critical_labels))
-                );
-                ?>
-            <?php endif; ?>
+        <p class="suple-onboarding-collapsed-message" role="status">
+            <?php _e('Has ocultado la guía rápida. Puedes reabrirla cuando quieras.', 'suple-speed'); ?>
         </p>
 
-        <div class="suple-onboarding-steps">
+        <div class="suple-onboarding-body" id="<?php echo esc_attr($onboarding_body_id); ?>" aria-hidden="<?php echo $onboarding_dismissed ? 'true' : 'false'; ?>">
+            <div class="suple-onboarding-progress">
+                <div class="suple-onboarding-progress-bar">
+                    <span class="suple-onboarding-progress-bar-fill" style="width: <?php echo esc_attr($onboarding_progress); ?>%;"></span>
+                </div>
+                <span class="suple-onboarding-progress-label"><?php echo esc_html($onboarding_progress); ?>%</span>
+            </div>
+
+            <p class="suple-onboarding-status <?php echo empty($onboarding_critical_remaining) ? 'success' : 'warning'; ?>"
+               data-warning-template="<?php echo esc_attr__('Quedan %1$s pasos críticos por completar: %2$s', 'suple-speed'); ?>"
+               data-success-text="<?php echo esc_attr__('¡Listo! Todas las optimizaciones críticas están activas.', 'suple-speed'); ?>">
+                <?php if (empty($onboarding_critical_remaining)): ?>
+                    <?php _e('¡Listo! Todas las optimizaciones críticas están activas.', 'suple-speed'); ?>
+                <?php else: ?>
+                    <?php
+                    printf(
+                        esc_html__('Quedan %1$s pasos críticos por completar: %2$s', 'suple-speed'),
+                        count($onboarding_critical_remaining),
+                        esc_html(implode(', ', $onboarding_critical_labels))
+                    );
+                    ?>
+                <?php endif; ?>
+            </p>
+
+            <div class="suple-onboarding-steps">
             <?php foreach ($onboarding_steps as $step_key => $step):
                 $completed = !empty($onboarding_state[$step_key]);
                 $links = $step['links'] ?? [];
@@ -320,6 +349,7 @@ $onboarding_critical_labels = array_map(function($step) {
                 </div>
             </label>
             <?php endforeach; ?>
+            </div>
         </div>
     </div>
     <?php endif; ?>


### PR DESCRIPTION
## Summary
- add dismiss and reopen controls to the onboarding card on the admin dashboard
- persist the onboarding dismissal flag through the existing AJAX handler
- update admin JavaScript and styles to hide or restore the onboarding card

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cd7c747d608330830a9a0a23b543eb