### PR TITLE
Add admin actions for rules, logs, and cache tools

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -48,6 +48,11 @@ class Admin {
         add_action('wp_ajax_suple_speed_reset_settings', [$this, 'ajax_reset_settings']);
         add_action('wp_ajax_suple_speed_export_settings', [$this, 'ajax_export_settings']);
         add_action('wp_ajax_suple_speed_import_settings', [$this, 'ajax_import_settings']);
+        add_action('wp_ajax_suple_speed_import_rules', [$this, 'ajax_import_rules']);
+        add_action('wp_ajax_suple_speed_clear_lqip_cache', [$this, 'ajax_clear_lqip_cache']);
+        add_action('wp_ajax_suple_speed_export_logs', [$this, 'ajax_export_logs']);
+        add_action('wp_ajax_suple_speed_clear_logs', [$this, 'ajax_clear_logs']);
+        add_action('wp_ajax_suple_speed_test_cache_warmup', [$this, 'ajax_test_cache_warmup']);
 
         add_action('wp_ajax_suple_speed_update_onboarding', [$this, 'ajax_update_onboarding']);
 
@@ -392,6 +397,7 @@ class Admin {
         wp_localize_script('suple-speed-admin', 'supleSpeedAdmin', [
             'nonce' => wp_create_nonce('suple_speed_nonce'),
             'ajaxUrl' => admin_url('admin-ajax.php'),
+            'homeUrl' => home_url('/'),
             'assetGroups' => $asset_groups,
             'manualAssetGroups' => $manual_overrides,
             'bundleStatus' => $bundle_status,
@@ -426,6 +432,7 @@ class Admin {
                 'processing' => __('Processing...', 'suple-speed'),
                 'scanningHandles' => __('Scanning handles…', 'suple-speed'),
                 'scanHandlesError' => __('We could not retrieve the handles for this page.', 'suple-speed'),
+                'confirmClearLogs' => __('Are you sure you want to clear the stored logs?', 'suple-speed'),
                 'success' => __('Operation completed successfully', 'suple-speed'),
                 'error' => __('An error occurred', 'suple-speed')
             ]
@@ -793,6 +800,278 @@ class Admin {
         wp_send_json_success([
             'message' => __('Settings imported successfully', 'suple-speed'),
             'imported_from_version' => $import_data['version'] ?? 'unknown'
+        ]);
+    }
+
+    /**
+     * AJAX: Importar reglas
+     */
+    public function ajax_import_rules() {
+        check_ajax_referer('suple_speed_nonce', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(__('Unauthorized', 'suple-speed'));
+        }
+
+        if (!isset($_FILES['rules_file'])) {
+            wp_send_json_error(__('No file uploaded', 'suple-speed'));
+        }
+
+        $file = $_FILES['rules_file'];
+
+        if ($file['error'] !== UPLOAD_ERR_OK) {
+            wp_send_json_error(__('File upload error', 'suple-speed'));
+        }
+
+        $contents = file_get_contents($file['tmp_name']);
+
+        if ($contents === false) {
+            wp_send_json_error(__('Unable to read the uploaded file', 'suple-speed'));
+        }
+
+        $decoded = json_decode($contents, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            wp_send_json_error(__('Invalid JSON file', 'suple-speed'));
+        }
+
+        if (isset($decoded['rules']) && is_array($decoded['rules'])) {
+            $rules_data = $decoded['rules'];
+        } elseif (is_array($decoded)) {
+            $rules_data = $decoded;
+        } else {
+            wp_send_json_error(__('Invalid rules file format', 'suple-speed'));
+        }
+
+        if (!function_exists('suple_speed') || !isset(suple_speed()->rules)) {
+            wp_send_json_error(__('Rules module not available', 'suple-speed'));
+        }
+
+        $replace = filter_var($_POST['replace'] ?? false, FILTER_VALIDATE_BOOLEAN);
+
+        $rules_module = suple_speed()->rules;
+        $imported = $rules_module->import_rules($rules_data, $replace);
+
+        $message = sprintf(
+            _n('%d rule imported successfully.', '%d rules imported successfully.', $imported, 'suple-speed'),
+            $imported
+        );
+
+        wp_send_json_success([
+            'message' => $message,
+            'imported' => $imported,
+            'reload' => true
+        ]);
+    }
+
+    /**
+     * AJAX: Limpiar caché LQIP
+     */
+    public function ajax_clear_lqip_cache() {
+        check_ajax_referer('suple_speed_nonce', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(__('Unauthorized', 'suple-speed'));
+        }
+
+        if (!function_exists('suple_speed') || !isset(suple_speed()->images)) {
+            wp_send_json_error(__('Images module not available', 'suple-speed'));
+        }
+
+        $images_module = suple_speed()->images;
+        $cleared = (int) $images_module->cleanup_lqip_cache();
+        $stats = $images_module->get_optimization_stats();
+
+        $message = $cleared > 0
+            ? sprintf(_n('%d LQIP placeholder removed from cache.', '%d LQIP placeholders removed from cache.', $cleared, 'suple-speed'), $cleared)
+            : __('LQIP cache is already clean.', 'suple-speed');
+
+        wp_send_json_success([
+            'message' => $message,
+            'cleared' => $cleared,
+            'stats' => $stats
+        ]);
+    }
+
+    /**
+     * AJAX: Exportar logs
+     */
+    public function ajax_export_logs() {
+        check_ajax_referer('suple_speed_nonce', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(__('Unauthorized', 'suple-speed'));
+        }
+
+        if (!$this->logger && function_exists('suple_speed') && isset(suple_speed()->logger)) {
+            $this->logger = suple_speed()->logger;
+        }
+
+        if (!$this->logger) {
+            wp_send_json_error(__('Logger module not available', 'suple-speed'));
+        }
+
+        $format = sanitize_key($_POST['format'] ?? 'json');
+        $allowed_formats = ['json', 'csv', 'txt'];
+        if (!in_array($format, $allowed_formats, true)) {
+            $format = 'json';
+        }
+
+        $level = sanitize_text_field($_POST['level'] ?? '');
+        $module = sanitize_text_field($_POST['module'] ?? '');
+        $days = isset($_POST['days']) && $_POST['days'] !== '' ? intval($_POST['days']) : null;
+
+        if ($days !== null && $days <= 0) {
+            $days = null;
+        }
+
+        $level_filter = $level !== '' ? $level : null;
+        $module_filter = $module !== '' ? $module : null;
+
+        $logs = $this->logger->get_logs(10000, 0, $level_filter, $module_filter);
+
+        if ($days) {
+            $cutoff = time() - ($days * DAY_IN_SECONDS);
+            $logs = array_filter($logs, function($log) use ($cutoff) {
+                return isset($log->timestamp) && strtotime($log->timestamp) >= $cutoff;
+            });
+        }
+
+        $count = count($logs);
+        $content = $this->logger->export_logs($format, $level_filter, $module_filter, $days);
+        $filename = 'suple-speed-logs-' . date('Y-m-d-H-i-s') . '.' . $format;
+
+        switch ($format) {
+            case 'csv':
+                $mime = 'text/csv';
+                break;
+            case 'txt':
+                $mime = 'text/plain';
+                break;
+            default:
+                $mime = 'application/json';
+        }
+
+        $message = $count > 0
+            ? sprintf(_n('Exported %d log entry.', 'Exported %d log entries.', $count, 'suple-speed'), $count)
+            : __('No log entries matched the selected filters.', 'suple-speed');
+
+        wp_send_json_success([
+            'filename' => $filename,
+            'content' => $content,
+            'mime' => $mime,
+            'message' => $message,
+            'count' => $count
+        ]);
+    }
+
+    /**
+     * AJAX: Limpiar logs
+     */
+    public function ajax_clear_logs() {
+        check_ajax_referer('suple_speed_nonce', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(__('Unauthorized', 'suple-speed'));
+        }
+
+        if (!$this->logger && function_exists('suple_speed') && isset(suple_speed()->logger)) {
+            $this->logger = suple_speed()->logger;
+        }
+
+        if (!$this->logger) {
+            wp_send_json_error(__('Logger module not available', 'suple-speed'));
+        }
+
+        $level = sanitize_text_field($_POST['level'] ?? '');
+        $module = sanitize_text_field($_POST['module'] ?? '');
+        $days = isset($_POST['days']) && $_POST['days'] !== '' ? intval($_POST['days']) : null;
+
+        if ($days !== null && $days <= 0) {
+            $days = null;
+        }
+
+        $level_filter = $level !== '' ? $level : null;
+        $module_filter = $module !== '' ? $module : null;
+
+        $cleared = $this->logger->clear_logs($level_filter, $module_filter, $days);
+
+        if ($cleared === false) {
+            wp_send_json_error(__('Unable to clear logs at this time.', 'suple-speed'));
+        }
+
+        $stats = $this->logger->get_log_stats();
+
+        $message = $cleared > 0
+            ? sprintf(_n('Removed %d log entry.', 'Removed %d log entries.', $cleared, 'suple-speed'), $cleared)
+            : __('No logs matched the selected filters.', 'suple-speed');
+
+        wp_send_json_success([
+            'message' => $message,
+            'cleared' => (int) $cleared,
+            'stats' => $stats
+        ]);
+    }
+
+    /**
+     * AJAX: Probar warmup de caché
+     */
+    public function ajax_test_cache_warmup() {
+        check_ajax_referer('suple_speed_nonce', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(__('Unauthorized', 'suple-speed'));
+        }
+
+        if (!function_exists('suple_speed') || !isset(suple_speed()->cache)) {
+            wp_send_json_error(__('Cache module not available', 'suple-speed'));
+        }
+
+        $url = esc_url_raw($_POST['url'] ?? home_url('/'));
+
+        if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
+            wp_send_json_error(__('Invalid URL provided for warmup test.', 'suple-speed'));
+        }
+
+        $cache_module = suple_speed()->cache;
+
+        $initial_stats = $cache_module->get_cache_stats();
+        $cache_module->purge_url($url);
+
+        $start = microtime(true);
+        $response = wp_remote_get($url, [
+            'timeout' => 20,
+            'headers' => [
+                'User-Agent' => 'Suple Speed Warmup Test/1.0',
+                'X-Suple-Speed-Warmup' => '1'
+            ]
+        ]);
+        $duration = microtime(true) - $start;
+
+        if (is_wp_error($response)) {
+            wp_send_json_error($response->get_error_message());
+        }
+
+        $status_code = wp_remote_retrieve_response_code($response);
+
+        if ($status_code >= 400) {
+            wp_send_json_error(sprintf(__('Warmup request returned status code %d', 'suple-speed'), $status_code));
+        }
+
+        $final_stats = $cache_module->get_cache_stats();
+        $files_delta = max(0, (int) ($final_stats['total_files'] - $initial_stats['total_files']));
+        $size_delta = max(0, (int) ($final_stats['total_size'] - $initial_stats['total_size']));
+
+        $message = __('Cache warmup request completed successfully.', 'suple-speed');
+
+        wp_send_json_success([
+            'message' => $message,
+            'url' => $url,
+            'status_code' => $status_code,
+            'response_time' => round($duration, 3),
+            'files_generated' => $files_delta,
+            'bytes_cached' => $size_delta,
+            'stats' => $final_stats
         ]);
     }
 


### PR DESCRIPTION
## Summary
- add admin-side controllers for importing rules, clearing LQIP cache, exporting/clearing logs, and testing cache warmup
- wire new AJAX endpoints in the admin class leveraging the rules, images, logger, and cache modules while returning consistent JSON payloads
- expose supporting localized data such as the home URL and confirmation strings for the new UI actions

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cd7c761de083309d702f451fe9401f