### PR TITLE
Align dashboard settings keys and document toggle test

### DIFF
--- a/tests/manual/dashboard-toggles.md
+++ b/tests/manual/dashboard-toggles.md
@@ -1,0 +1,20 @@
+# Dashboard Toggle Verification
+
+## Goal
+Confirm that enabling or disabling the **WebP/AVIF Conversion** toggle in the settings screen is reflected in the **Modern Formats** status badge inside the dashboard.
+
+## Prerequisites
+- WordPress admin access with the Suple Speed plugin activated.
+- Ability to visit both the Suple Speed **Settings** and **Dashboard** pages.
+
+## Steps
+1. Navigate to **Settings → Suple Speed** and open the **Images** tab.
+2. Locate the **WebP/AVIF Conversion** toggle and set it to **Enabled**.
+3. Click **Save Changes**.
+4. Open **Dashboard → Suple Speed** (refresh if already open).
+5. Verify that, under **Images → Optimization Status**, the **Modern Formats** badge shows **Enabled**.
+6. Return to the **Images** tab in the settings, disable the **WebP/AVIF Conversion** toggle, and save.
+7. Reload the Suple Speed dashboard and confirm the **Modern Formats** badge now shows **Disabled**.
+
+## Expected Result
+The dashboard immediately reflects the toggle state after saving the settings, showing **Enabled** when the toggle is on and **Disabled** when it is off.

--- a/views/admin-dashboard.php
+++ b/views/admin-dashboard.php
@@ -127,7 +127,7 @@ if ($fonts_module && method_exists($fonts_module, 'get_font_preloads')) {
 }
 
 $asset_preloads = $current_settings['preload_assets'] ?? [];
-$critical_css   = $current_settings['critical_css'] ?? '';
+$critical_css   = $current_settings['critical_css_general'] ?? '';
 
 $compat_module = function_exists('suple_speed') ? suple_speed()->compat : null;
 $compat_report_defaults = [
@@ -734,8 +734,8 @@ $onboarding_critical_labels = array_map(function($step) {
                             <?php echo !empty($current_settings['compression_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
                         </li>
                         <li>
-                            <strong><?php _e('Logged-in Cache', 'suple-speed'); ?>:</strong>
-                            <?php echo !empty($current_settings['cache_logged_users']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                            <strong><?php _e('Critical CSS', 'suple-speed'); ?>:</strong>
+                            <?php echo !empty($current_settings['critical_css_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
                         </li>
                     </ul>
                     <a class="suple-button" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-cache')); ?>">
@@ -951,7 +951,7 @@ $onboarding_critical_labels = array_map(function($step) {
                         </li>
                         <li>
                             <strong><?php _e('Modern Formats', 'suple-speed'); ?>:</strong>
-                            <?php echo !empty($current_settings['images_modern']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                            <?php echo !empty($current_settings['images_webp_rewrite']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
                         </li>
                     </ul>
                     <a class="suple-button" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-images')); ?>">


### PR DESCRIPTION
## Summary
- update the dashboard image status badge to read the images_webp_rewrite toggle and fix other setting key references to match sanitize_settings
- replace the obsolete logged-in cache indicator with the critical CSS status to avoid undefined keys
- add a manual verification guide that confirms the WebP/AVIF toggle state is reflected in the dashboard

## Testing
- php -l views/admin-dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cd7c7aab7083309b46e221fcf1dbc5