### PR TITLE
Add CDN purging integrations

### DIFF
--- a/includes/class-cdn.php
+++ b/includes/class-cdn.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace SupleSpeed;
+
+/**
+ * Gestión de integraciones CDN
+ */
+class CDN {
+
+    /**
+     * Logger del sistema
+     */
+    private $logger;
+
+    public function __construct() {
+        if (function_exists('suple_speed')) {
+            $this->logger = suple_speed()->logger;
+        }
+    }
+
+    /**
+     * Purga el CDN configurado
+     *
+     * @param string $type Tipo de purga: all|urls
+     * @param array $urls  Lista de URLs a purgar en el CDN
+     *
+     * @return array
+     */
+    public function purge($type = 'all', $urls = []) {
+        $results = [];
+        $providers = $this->get_enabled_providers();
+
+        if (empty($providers)) {
+            return $results;
+        }
+
+        foreach ($providers as $provider => $config) {
+            switch ($provider) {
+                case 'cloudflare':
+                    $results[$provider] = $this->purge_cloudflare($type, $urls, $config);
+                    break;
+
+                case 'bunnycdn':
+                    $results[$provider] = $this->purge_bunnycdn($type, $urls, $config);
+                    break;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Obtiene los proveedores con credenciales válidas
+     */
+    private function get_enabled_providers() {
+        $settings = get_option('suple_speed_settings', []);
+        $providers = $settings['cdn_integrations'] ?? [];
+
+        if (!is_array($providers)) {
+            return [];
+        }
+
+        $enabled = [];
+
+        foreach ($providers as $provider => $config) {
+            if (!is_array($config) || empty($config['enabled'])) {
+                continue;
+            }
+
+            $enabled[$provider] = $config;
+        }
+
+        return $enabled;
+    }
+
+    /**
+     * Purga Cloudflare
+     */
+    private function purge_cloudflare($type, $urls, $config) {
+        $label = 'Cloudflare';
+
+        $api_token = trim($config['api_token'] ?? '');
+        $zone_id = trim($config['zone_id'] ?? '');
+
+        if ($api_token === '' || $zone_id === '') {
+            $message = sprintf(__('Missing Cloudflare credentials. Please review your %s configuration.', 'suple-speed'), $label);
+            $this->log_warning($label, $message, ['zone_id' => $zone_id]);
+
+            return [
+                'provider' => 'cloudflare',
+                'label' => $label,
+                'success' => false,
+                'message' => $message,
+            ];
+        }
+
+        $endpoint = sprintf('https://api.cloudflare.com/client/v4/zones/%s/purge_cache', rawurlencode($zone_id));
+        $payload = $this->build_cloudflare_payload($type, $urls);
+
+        if (empty($payload)) {
+            return [
+                'provider' => 'cloudflare',
+                'label' => $label,
+                'success' => true,
+                'message' => __('No Cloudflare purge required for the requested action.', 'suple-speed'),
+            ];
+        }
+
+        $response = wp_remote_post($endpoint, [
+            'headers' => [
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer ' . $api_token,
+            ],
+            'timeout' => 20,
+            'body' => wp_json_encode($payload),
+        ]);
+
+        if (is_wp_error($response)) {
+            $error_message = $response->get_error_message();
+            $this->log_error($label, 'Cloudflare purge request failed', [
+                'error' => $error_message,
+                'type' => $type,
+            ]);
+
+            return [
+                'provider' => 'cloudflare',
+                'label' => $label,
+                'success' => false,
+                'message' => sprintf(__('Cloudflare purge failed: %s', 'suple-speed'), $error_message),
+            ];
+        }
+
+        $status_code = wp_remote_retrieve_response_code($response);
+        $body = json_decode(wp_remote_retrieve_body($response), true);
+        $success = ($status_code >= 200 && $status_code < 300) && ($body['success'] ?? false);
+
+        if ($success) {
+            $this->log_info($label, 'Cloudflare purge requested successfully', [
+                'type' => $type,
+                'urls' => $payload['files'] ?? [],
+            ]);
+
+            return [
+                'provider' => 'cloudflare',
+                'label' => $label,
+                'success' => true,
+                'message' => __('Cloudflare purge requested successfully.', 'suple-speed'),
+            ];
+        }
+
+        $error_message = $this->extract_cloudflare_error($body);
+
+        $this->log_error($label, 'Cloudflare purge returned an error', [
+            'type' => $type,
+            'response_code' => $status_code,
+            'response_body' => $body,
+        ]);
+
+        return [
+            'provider' => 'cloudflare',
+            'label' => $label,
+            'success' => false,
+            'message' => sprintf(__('Cloudflare purge failed: %s', 'suple-speed'), $error_message),
+        ];
+    }
+
+    /**
+     * Construye el payload para Cloudflare
+     */
+    private function build_cloudflare_payload($type, $urls) {
+        if ($type === 'all') {
+            return ['purge_everything' => true];
+        }
+
+        $prepared_urls = $this->prepare_urls($urls);
+
+        if (empty($prepared_urls)) {
+            return [];
+        }
+
+        return ['files' => $prepared_urls];
+    }
+
+    /**
+     * Extrae mensaje de error desde Cloudflare
+     */
+    private function extract_cloudflare_error($body) {
+        if (empty($body)) {
+            return __('Unknown error', 'suple-speed');
+        }
+
+        if (!empty($body['errors']) && is_array($body['errors'])) {
+            $error = $body['errors'][0];
+
+            if (is_array($error)) {
+                $message = $error['message'] ?? '';
+                $code = $error['code'] ?? '';
+
+                if ($code !== '') {
+                    return trim(sprintf('%s (%s)', $message, $code));
+                }
+
+                if ($message !== '') {
+                    return $message;
+                }
+            } elseif (is_string($error)) {
+                return $error;
+            }
+        }
+
+        if (!empty($body['messages'])) {
+            return implode(', ', array_filter(array_map('strval', (array) $body['messages'])));
+        }
+
+        return __('Unknown error', 'suple-speed');
+    }
+
+    /**
+     * Purga BunnyCDN
+     */
+    private function purge_bunnycdn($type, $urls, $config) {
+        $label = 'BunnyCDN';
+
+        $api_key = trim($config['api_key'] ?? '');
+        $zone_id = trim($config['zone_id'] ?? '');
+
+        if ($api_key === '' || $zone_id === '') {
+            $message = sprintf(__('Missing BunnyCDN credentials. Please review your %s configuration.', 'suple-speed'), $label);
+            $this->log_warning($label, $message, ['zone_id' => $zone_id]);
+
+            return [
+                'provider' => 'bunnycdn',
+                'label' => $label,
+                'success' => false,
+                'message' => $message,
+            ];
+        }
+
+        if ($type === 'all') {
+            return $this->purge_bunnycdn_zone($zone_id, $api_key, $label);
+        }
+
+        $prepared_urls = $this->prepare_urls($urls);
+
+        if (empty($prepared_urls)) {
+            return [
+                'provider' => 'bunnycdn',
+                'label' => $label,
+                'success' => true,
+                'message' => __('No BunnyCDN purge required for the requested action.', 'suple-speed'),
+            ];
+        }
+
+        $errors = [];
+
+        foreach ($prepared_urls as $url) {
+            $response = wp_remote_post('https://api.bunny.net/purge', [
+                'headers' => [
+                    'AccessKey' => $api_key,
+                    'Content-Type' => 'application/json',
+                ],
+                'timeout' => 20,
+                'body' => wp_json_encode(['url' => $url]),
+            ]);
+
+            if (is_wp_error($response)) {
+                $errors[] = $response->get_error_message();
+                continue;
+            }
+
+            $status_code = wp_remote_retrieve_response_code($response);
+
+            if ($status_code < 200 || $status_code >= 300) {
+                $errors[] = sprintf('%s (%d)', $url, $status_code);
+            }
+        }
+
+        if (empty($errors)) {
+            $this->log_info($label, 'BunnyCDN URLs purged successfully', [
+                'urls' => $prepared_urls,
+            ]);
+
+            return [
+                'provider' => 'bunnycdn',
+                'label' => $label,
+                'success' => true,
+                'message' => __('BunnyCDN URLs purged successfully.', 'suple-speed'),
+            ];
+        }
+
+        $this->log_error($label, 'BunnyCDN URL purge completed with errors', [
+            'errors' => $errors,
+            'urls' => $prepared_urls,
+        ]);
+
+        return [
+            'provider' => 'bunnycdn',
+            'label' => $label,
+            'success' => false,
+            'message' => sprintf(__('BunnyCDN purge failed for some URLs: %s', 'suple-speed'), implode(', ', $errors)),
+        ];
+    }
+
+    /**
+     * Purga completa de zona en BunnyCDN
+     */
+    private function purge_bunnycdn_zone($zone_id, $api_key, $label) {
+        $endpoint = sprintf('https://api.bunny.net/pullzone/%s/purgeCache', rawurlencode($zone_id));
+
+        $response = wp_remote_post($endpoint, [
+            'headers' => [
+                'AccessKey' => $api_key,
+            ],
+            'timeout' => 20,
+        ]);
+
+        if (is_wp_error($response)) {
+            $error_message = $response->get_error_message();
+
+            $this->log_error($label, 'BunnyCDN full purge request failed', [
+                'error' => $error_message,
+            ]);
+
+            return [
+                'provider' => 'bunnycdn',
+                'label' => $label,
+                'success' => false,
+                'message' => sprintf(__('BunnyCDN purge failed: %s', 'suple-speed'), $error_message),
+            ];
+        }
+
+        $status_code = wp_remote_retrieve_response_code($response);
+
+        if ($status_code >= 200 && $status_code < 300) {
+            $this->log_info($label, 'BunnyCDN zone purge requested successfully', [
+                'zone_id' => $zone_id,
+            ]);
+
+            return [
+                'provider' => 'bunnycdn',
+                'label' => $label,
+                'success' => true,
+                'message' => __('BunnyCDN purge requested successfully.', 'suple-speed'),
+            ];
+        }
+
+        $body = wp_remote_retrieve_body($response);
+
+        $this->log_error($label, 'BunnyCDN returned a non-success status', [
+            'status_code' => $status_code,
+            'response_body' => $body,
+        ]);
+
+        return [
+            'provider' => 'bunnycdn',
+            'label' => $label,
+            'success' => false,
+            'message' => sprintf(__('BunnyCDN purge failed with status code %d', 'suple-speed'), $status_code),
+        ];
+    }
+
+    /**
+     * Normaliza URLs para purga
+     */
+    private function prepare_urls($urls) {
+        if (!is_array($urls)) {
+            $urls = [$urls];
+        }
+
+        $prepared = [];
+
+        foreach ($urls as $url) {
+            $url = trim((string) $url);
+
+            if ($url === '') {
+                continue;
+            }
+
+            if (!preg_match('#^https?://#i', $url)) {
+                $url = home_url($url);
+            }
+
+            $prepared[] = esc_url_raw($url);
+        }
+
+        return array_values(array_unique(array_filter($prepared)));
+    }
+
+    /**
+     * Helper para log info
+     */
+    private function log_info($provider, $message, $context = []) {
+        if ($this->logger) {
+            $this->logger->info($message, array_merge($context, [
+                'provider' => $provider,
+            ]), 'cdn');
+        }
+    }
+
+    /**
+     * Helper para log warning
+     */
+    private function log_warning($provider, $message, $context = []) {
+        if ($this->logger) {
+            $this->logger->warning($message, array_merge($context, [
+                'provider' => $provider,
+            ]), 'cdn');
+        }
+    }
+
+    /**
+     * Helper para log error
+     */
+    private function log_error($provider, $message, $context = []) {
+        if ($this->logger) {
+            $this->logger->error($message, array_merge($context, [
+                'provider' => $provider,
+            ]), 'cdn');
+        }
+    }
+}

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -33,6 +33,7 @@
             
             // Guardar configuración
             $(document).on('click', '.suple-save-settings', this.saveSettings);
+            $(document).on('click', '.suple-save-cdn-settings', this.saveCdnSettings);
             
             // Resetear configuración
             $(document).on('click', '.suple-reset-settings', this.resetSettings);
@@ -282,9 +283,21 @@
                 $button.text(originalText);
                 $button.prop('disabled', false);
                 SupleSpeedAdmin.showNotice('success', data.message);
-                
+
                 // Actualizar estadísticas si están visibles
                 SupleSpeedAdmin.updateCacheStats();
+
+                if (data.cdn_results) {
+                    const results = Array.isArray(data.cdn_results)
+                        ? data.cdn_results
+                        : Object.values(data.cdn_results);
+
+                    results.forEach(function(result) {
+                        if (!result || !result.message) return;
+
+                        SupleSpeedAdmin.showNotice(result.success ? 'success' : 'error', result.message);
+                    });
+                }
             }, function(error) {
                 $button.text(originalText);
                 $button.prop('disabled', false);
@@ -495,6 +508,42 @@
                 $button.text(originalText);
                 $button.prop('disabled', false);
                 SupleSpeedAdmin.showNotice('error', error);
+            });
+        },
+
+        saveCdnSettings: function(e) {
+            e.preventDefault();
+
+            const $button = $(this);
+            const $form = $button.closest('form');
+            const originalText = $button.text();
+
+            const payload = {
+                cloudflare: {
+                    enabled: $form.find('[name="cdn_cloudflare_enabled"]').is(':checked'),
+                    api_token: ($form.find('[name="cdn_cloudflare_api_token"]').val() || '').trim(),
+                    zone_id: ($form.find('[name="cdn_cloudflare_zone_id"]').val() || '').trim()
+                },
+                bunnycdn: {
+                    enabled: $form.find('[name="cdn_bunnycdn_enabled"]').is(':checked'),
+                    api_key: ($form.find('[name="cdn_bunnycdn_api_key"]').val() || '').trim(),
+                    zone_id: ($form.find('[name="cdn_bunnycdn_zone_id"]').val() || '').trim()
+                }
+            };
+
+            $button.html('<span class="suple-spinner"></span> ' + supleSpeedAdmin.strings.processing);
+            $button.prop('disabled', true);
+
+            SupleSpeedAdmin.ajaxRequest('save_cdn_settings', {
+                cdn: payload
+            }, function(data) {
+                $button.text(originalText);
+                $button.prop('disabled', false);
+                SupleSpeedAdmin.showNotice('success', data.message || (supleSpeedAdmin.strings.success || 'Saved'));
+            }, function(error) {
+                $button.text(originalText);
+                $button.prop('disabled', false);
+                SupleSpeedAdmin.showNotice('error', error || supleSpeedAdmin.strings.error);
             });
         },
 

--- a/suple-speed.php
+++ b/suple-speed.php
@@ -45,6 +45,7 @@ class SupleSpeed {
      */
     public $admin;
     public $cache;
+    public $cdn;
     public $assets;
     public $fonts;
     public $images;
@@ -140,6 +141,7 @@ class SupleSpeed {
         require_once SUPLE_SPEED_PLUGIN_DIR . 'includes/class-compat.php';
         require_once SUPLE_SPEED_PLUGIN_DIR . 'includes/class-elementor-guard.php';
         require_once SUPLE_SPEED_PLUGIN_DIR . 'includes/class-rules.php';
+        require_once SUPLE_SPEED_PLUGIN_DIR . 'includes/class-cdn.php';
         require_once SUPLE_SPEED_PLUGIN_DIR . 'includes/class-cache.php';
         require_once SUPLE_SPEED_PLUGIN_DIR . 'includes/class-assets.php';
         require_once SUPLE_SPEED_PLUGIN_DIR . 'includes/class-fonts.php';
@@ -152,6 +154,7 @@ class SupleSpeed {
         $this->compat = new SupleSpeed\Compat();
         $this->elementor_guard = new SupleSpeed\ElementorGuard();
         $this->rules = new SupleSpeed\Rules();
+        $this->cdn = new SupleSpeed\CDN();
         $this->cache = new SupleSpeed\Cache();
         $this->assets = new SupleSpeed\Assets();
         $this->fonts = new SupleSpeed\Fonts();
@@ -439,7 +442,19 @@ class SupleSpeed {
             'elementor_compat' => true,
             'safe_mode' => false,
             'log_level' => 'info',
-            'multisite_network' => false
+            'multisite_network' => false,
+            'cdn_integrations' => [
+                'cloudflare' => [
+                    'enabled' => false,
+                    'api_token' => '',
+                    'zone_id' => '',
+                ],
+                'bunnycdn' => [
+                    'enabled' => false,
+                    'api_key' => '',
+                    'zone_id' => '',
+                ],
+            ],
         ];
         
         add_option('suple_speed_settings', $default_settings);

--- a/views/admin-dashboard.php
+++ b/views/admin-dashboard.php
@@ -147,6 +147,28 @@ $images_defaults = [
 ];
 $images_stats = wp_parse_args($dashboard_data['images_stats'] ?? [], $images_defaults);
 
+$cdn_defaults = [
+    'cloudflare' => [
+        'enabled' => false,
+        'api_token' => '',
+        'zone_id' => '',
+    ],
+    'bunnycdn' => [
+        'enabled' => false,
+        'api_key' => '',
+        'zone_id' => '',
+    ],
+];
+
+$cdn_settings = $current_settings['cdn_integrations'] ?? [];
+if (!is_array($cdn_settings)) {
+    $cdn_settings = [];
+}
+
+$cdn_settings = wp_parse_args($cdn_settings, $cdn_defaults);
+$cloudflare_cdn = wp_parse_args($cdn_settings['cloudflare'] ?? [], $cdn_defaults['cloudflare']);
+$bunnycdn_cdn = wp_parse_args($cdn_settings['bunnycdn'] ?? [], $cdn_defaults['bunnycdn']);
+
 $cache_module = function_exists('suple_speed') ? suple_speed()->cache : null;
 $logger_module = function_exists('suple_speed') ? suple_speed()->logger : null;
 $rules_module  = function_exists('suple_speed') ? suple_speed()->rules : null;
@@ -1161,6 +1183,73 @@ $onboarding_critical_labels = array_map(function($step) {
             </div>
 
             <div class="suple-card suple-mt-2">
+                <h3><?php _e('CDN Integrations', 'suple-speed'); ?></h3>
+                <p><?php _e('Store API credentials so Suple Speed can purge your CDN after clearing the local cache.', 'suple-speed'); ?></p>
+
+                <form id="suple-cdn-settings-form" class="suple-form suple-mt-1" autocomplete="off">
+                    <div class="suple-cdn-provider">
+                        <h4><?php _e('Cloudflare', 'suple-speed'); ?></h4>
+
+                        <div class="suple-form-row">
+                            <div class="suple-form-toggle">
+                                <div class="suple-toggle">
+                                    <input type="checkbox" id="cdn-cloudflare-enabled" name="cdn_cloudflare_enabled" <?php checked($cloudflare_cdn['enabled']); ?>>
+                                    <span class="suple-toggle-slider"></span>
+                                </div>
+                                <label for="cdn-cloudflare-enabled" class="suple-form-label"><?php _e('Enable Cloudflare purging', 'suple-speed'); ?></label>
+                            </div>
+                            <div class="suple-form-help"><?php _e('Trigger a Cloudflare cache purge whenever the local cache is cleared.', 'suple-speed'); ?></div>
+                        </div>
+
+                        <div class="suple-form-row">
+                            <label for="cdn-cloudflare-zone" class="suple-form-label"><?php _e('Zone ID', 'suple-speed'); ?></label>
+                            <input type="text" id="cdn-cloudflare-zone" name="cdn_cloudflare_zone_id" class="suple-form-input" value="<?php echo esc_attr($cloudflare_cdn['zone_id']); ?>" autocomplete="off">
+                            <div class="suple-form-help"><?php _e('Copy the Zone ID from your Cloudflare dashboard.', 'suple-speed'); ?></div>
+                        </div>
+
+                        <div class="suple-form-row">
+                            <label for="cdn-cloudflare-token" class="suple-form-label"><?php _e('API Token', 'suple-speed'); ?></label>
+                            <input type="password" id="cdn-cloudflare-token" name="cdn_cloudflare_api_token" class="suple-form-input" value="<?php echo esc_attr($cloudflare_cdn['api_token']); ?>" autocomplete="new-password">
+                            <div class="suple-form-help"><?php _e('Use a token with “Cache Purge” permissions.', 'suple-speed'); ?></div>
+                        </div>
+                    </div>
+
+                    <div class="suple-cdn-provider suple-mt-2">
+                        <h4><?php _e('BunnyCDN', 'suple-speed'); ?></h4>
+
+                        <div class="suple-form-row">
+                            <div class="suple-form-toggle">
+                                <div class="suple-toggle">
+                                    <input type="checkbox" id="cdn-bunny-enabled" name="cdn_bunnycdn_enabled" <?php checked($bunnycdn_cdn['enabled']); ?>>
+                                    <span class="suple-toggle-slider"></span>
+                                </div>
+                                <label for="cdn-bunny-enabled" class="suple-form-label"><?php _e('Enable BunnyCDN purging', 'suple-speed'); ?></label>
+                            </div>
+                            <div class="suple-form-help"><?php _e('Send purge requests to your BunnyCDN pull zone after local cache clears.', 'suple-speed'); ?></div>
+                        </div>
+
+                        <div class="suple-form-row">
+                            <label for="cdn-bunny-zone" class="suple-form-label"><?php _e('Pull Zone ID', 'suple-speed'); ?></label>
+                            <input type="text" id="cdn-bunny-zone" name="cdn_bunnycdn_zone_id" class="suple-form-input" value="<?php echo esc_attr($bunnycdn_cdn['zone_id']); ?>" autocomplete="off">
+                            <div class="suple-form-help"><?php _e('Enter the numeric ID or name of the pull zone to purge.', 'suple-speed'); ?></div>
+                        </div>
+
+                        <div class="suple-form-row">
+                            <label for="cdn-bunny-key" class="suple-form-label"><?php _e('API Key', 'suple-speed'); ?></label>
+                            <input type="password" id="cdn-bunny-key" name="cdn_bunnycdn_api_key" class="suple-form-input" value="<?php echo esc_attr($bunnycdn_cdn['api_key']); ?>" autocomplete="new-password">
+                            <div class="suple-form-help"><?php _e('Use the API Access Key from the BunnyCDN dashboard.', 'suple-speed'); ?></div>
+                        </div>
+                    </div>
+
+                    <div class="suple-button-group suple-mt-2">
+                        <button type="button" class="suple-button suple-save-cdn-settings">
+                            <?php _e('Save CDN Credentials', 'suple-speed'); ?>
+                        </button>
+                    </div>
+                </form>
+            </div>
+
+            <div class="suple-card suple-mt-2">
                 <h3><?php _e('Diagnostics', 'suple-speed'); ?></h3>
                 <p><?php _e('Use these helpers to verify that core services are working as expected.', 'suple-speed'); ?></p>
                 <div class="suple-button-group">
@@ -1539,3 +1628,11 @@ jQuery(document).ready(function($) {
     loadRecentActivity();
 });
 </script>
+.suple-cdn-provider + .suple-cdn-provider {
+    margin-top: 24px;
+}
+
+.suple-cdn-provider h4 {
+    margin-top: 0;
+}
+


### PR DESCRIPTION
## Summary
- add a CDN integration module to handle Cloudflare and BunnyCDN purge requests with logging
- connect existing cache purge flows so remote CDNs are cleared after local cache cleanup and surface results in the UI
- provide a Tools tab form and AJAX endpoint to store CDN credentials securely in plugin settings

## Testing
- php -l includes/class-cdn.php
- php -l includes/class-cache.php
- php -l includes/class-admin.php
- php -l suple-speed.php
- php -l views/admin-dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cd7c89be68833089bba9dcbc0ba100