### PR TITLE
Add Getting Started tab panel for onboarding

### DIFF
--- a/views/admin-dashboard.php
+++ b/views/admin-dashboard.php
@@ -82,10 +82,6 @@ $tabs = [
     ],
 ];
 
-if (empty($active_tab) || !isset($tabs[$active_tab])) {
-    $active_tab = 'overview';
-}
-
 $psi_defaults = [
     'total_tests'              => 0,
     'avg_performance_mobile'   => 0,
@@ -285,6 +281,17 @@ $onboarding_critical_labels = array_map(function($step) {
     return $step['title'];
 }, $onboarding_critical_remaining);
 
+if ($onboarding_total > 0) {
+    $tabs = ['getting-started' => [
+        'label' => __('Guía rápida', 'suple-speed'),
+        'icon'  => 'dashicons-welcome-learn-more',
+    ]] + $tabs;
+}
+
+if (empty($active_tab) || !isset($tabs[$active_tab])) {
+    $active_tab = 'overview';
+}
+
 ?>
 
 <div class="suple-speed-admin">
@@ -318,101 +325,103 @@ $onboarding_critical_labels = array_map(function($step) {
 
     <!-- Getting Started -->
     <?php if ($onboarding_total > 0): ?>
-    <div class="suple-card suple-onboarding <?php echo $onboarding_dismissed ? 'is-dismissed' : ''; ?>"
-         data-total="<?php echo esc_attr($onboarding_total); ?>"
-         data-completed="<?php echo esc_attr($onboarding_completed); ?>"
-         data-dismissed="<?php echo $onboarding_dismissed ? '1' : '0'; ?>">
-        <div class="suple-onboarding-head">
-            <div class="suple-onboarding-title">
-                <h3><?php _e('Guía rápida', 'suple-speed'); ?></h3>
-                <span class="suple-onboarding-progress-count"><?php echo esc_html(sprintf('%d/%d', $onboarding_completed, $onboarding_total)); ?></span>
-            </div>
-            <div class="suple-onboarding-actions">
-                <button type="button"
-                        class="suple-onboarding-toggle suple-onboarding-dismiss"
-                        aria-controls="<?php echo esc_attr($onboarding_body_id); ?>"
-                        aria-expanded="<?php echo $onboarding_dismissed ? 'false' : 'true'; ?>">
-                    <span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
-                    <span><?php _e('Ocultar', 'suple-speed'); ?></span>
-                </button>
-                <button type="button"
-                        class="suple-onboarding-toggle suple-onboarding-reopen"
-                        aria-controls="<?php echo esc_attr($onboarding_body_id); ?>"
-                        aria-expanded="<?php echo $onboarding_dismissed ? 'false' : 'true'; ?>">
-                    <span class="dashicons dashicons-visibility" aria-hidden="true"></span>
-                    <span><?php _e('Mostrar', 'suple-speed'); ?></span>
-                </button>
-            </div>
-        </div>
-
-        <p class="suple-onboarding-collapsed-message" role="status">
-            <?php _e('Has ocultado la guía rápida. Puedes reabrirla cuando quieras.', 'suple-speed'); ?>
-        </p>
-
-        <div class="suple-onboarding-body" id="<?php echo esc_attr($onboarding_body_id); ?>" aria-hidden="<?php echo $onboarding_dismissed ? 'true' : 'false'; ?>">
-            <div class="suple-onboarding-progress">
-                <div class="suple-onboarding-progress-bar">
-                    <span class="suple-onboarding-progress-bar-fill" style="width: <?php echo esc_attr($onboarding_progress); ?>%;"></span>
+    <div class="suple-tab-panel <?php echo $active_tab === 'getting-started' ? 'is-active' : ''; ?>" data-tab="getting-started">
+        <div class="suple-card suple-onboarding <?php echo $onboarding_dismissed ? 'is-dismissed' : ''; ?>"
+             data-total="<?php echo esc_attr($onboarding_total); ?>"
+             data-completed="<?php echo esc_attr($onboarding_completed); ?>"
+             data-dismissed="<?php echo $onboarding_dismissed ? '1' : '0'; ?>">
+            <div class="suple-onboarding-head">
+                <div class="suple-onboarding-title">
+                    <h3><?php _e('Guía rápida', 'suple-speed'); ?></h3>
+                    <span class="suple-onboarding-progress-count"><?php echo esc_html(sprintf('%d/%d', $onboarding_completed, $onboarding_total)); ?></span>
                 </div>
-                <span class="suple-onboarding-progress-label"><?php echo esc_html($onboarding_progress); ?>%</span>
+                <div class="suple-onboarding-actions">
+                    <button type="button"
+                            class="suple-onboarding-toggle suple-onboarding-dismiss"
+                            aria-controls="<?php echo esc_attr($onboarding_body_id); ?>"
+                            aria-expanded="<?php echo $onboarding_dismissed ? 'false' : 'true'; ?>">
+                        <span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
+                        <span><?php _e('Ocultar', 'suple-speed'); ?></span>
+                    </button>
+                    <button type="button"
+                            class="suple-onboarding-toggle suple-onboarding-reopen"
+                            aria-controls="<?php echo esc_attr($onboarding_body_id); ?>"
+                            aria-expanded="<?php echo $onboarding_dismissed ? 'false' : 'true'; ?>">
+                        <span class="dashicons dashicons-visibility" aria-hidden="true"></span>
+                        <span><?php _e('Mostrar', 'suple-speed'); ?></span>
+                    </button>
+                </div>
             </div>
 
-            <p class="suple-onboarding-status <?php echo empty($onboarding_critical_remaining) ? 'success' : 'warning'; ?>"
-               data-warning-template="<?php echo esc_attr__('Quedan %1$s pasos críticos por completar: %2$s', 'suple-speed'); ?>"
-               data-success-text="<?php echo esc_attr__('¡Listo! Todas las optimizaciones críticas están activas.', 'suple-speed'); ?>">
-                <?php if (empty($onboarding_critical_remaining)): ?>
-                    <?php _e('¡Listo! Todas las optimizaciones críticas están activas.', 'suple-speed'); ?>
-                <?php else: ?>
-                    <?php
-                    printf(
-                        esc_html__('Quedan %1$s pasos críticos por completar: %2$s', 'suple-speed'),
-                        count($onboarding_critical_remaining),
-                        esc_html(implode(', ', $onboarding_critical_labels))
-                    );
-                    ?>
-                <?php endif; ?>
+            <p class="suple-onboarding-collapsed-message" role="status">
+                <?php _e('Has ocultado la guía rápida. Puedes reabrirla cuando quieras.', 'suple-speed'); ?>
             </p>
 
-            <div class="suple-onboarding-steps">
-            <?php foreach ($onboarding_steps as $step_key => $step):
-                $completed = !empty($onboarding_state[$step_key]);
-                $links = $step['links'] ?? [];
-                $badge_class = $step['badge_class'] ?? 'info';
-                $aria_label = sprintf(__('Marcar "%s" como completado', 'suple-speed'), $step['title']);
-            ?>
-            <label class="suple-onboarding-card <?php echo $completed ? 'completed' : ''; ?>">
-                <input type="checkbox"
-                       class="suple-onboarding-step"
-                       data-step="<?php echo esc_attr($step_key); ?>"
-                       aria-label="<?php echo esc_attr($aria_label); ?>"
-                       <?php checked($completed); ?>>
-                <span class="suple-onboarding-marker" aria-hidden="true">
-                    <span class="dashicons dashicons-yes"></span>
-                </span>
-                <div class="suple-onboarding-content">
-                    <h4><?php echo esc_html($step['title']); ?></h4>
-                    <p><?php echo esc_html($step['description']); ?></p>
-
-                    <?php if (!empty($links)): ?>
-                    <div class="suple-onboarding-links">
-                        <?php foreach ($links as $link):
-                            $link_classes = !empty($link['secondary']) ? ' class="secondary"' : '';
-                        ?>
-                        <a href="<?php echo esc_url($link['url']); ?>"<?php echo $link_classes; ?>>
-                            <?php echo esc_html($link['label']); ?>
-                        </a>
-                        <?php endforeach; ?>
+            <div class="suple-onboarding-body" id="<?php echo esc_attr($onboarding_body_id); ?>" aria-hidden="<?php echo $onboarding_dismissed ? 'true' : 'false'; ?>">
+                <div class="suple-onboarding-progress">
+                    <div class="suple-onboarding-progress-bar">
+                        <span class="suple-onboarding-progress-bar-fill" style="width: <?php echo esc_attr($onboarding_progress); ?>%;"></span>
                     </div>
-                    <?php endif; ?>
-
-                    <?php if (!empty($step['badge'])): ?>
-                    <span class="suple-badge <?php echo esc_attr($badge_class); ?>">
-                        <?php echo esc_html($step['badge']); ?>
-                    </span>
-                    <?php endif; ?>
+                    <span class="suple-onboarding-progress-label"><?php echo esc_html($onboarding_progress); ?>%</span>
                 </div>
-            </label>
-            <?php endforeach; ?>
+
+                <p class="suple-onboarding-status <?php echo empty($onboarding_critical_remaining) ? 'success' : 'warning'; ?>"
+                   data-warning-template="<?php echo esc_attr__('Quedan %1$s pasos críticos por completar: %2$s', 'suple-speed'); ?>"
+                   data-success-text="<?php echo esc_attr__('¡Listo! Todas las optimizaciones críticas están activas.', 'suple-speed'); ?>">
+                    <?php if (empty($onboarding_critical_remaining)): ?>
+                        <?php _e('¡Listo! Todas las optimizaciones críticas están activas.', 'suple-speed'); ?>
+                    <?php else: ?>
+                        <?php
+                        printf(
+                            esc_html__('Quedan %1$s pasos críticos por completar: %2$s', 'suple-speed'),
+                            count($onboarding_critical_remaining),
+                            esc_html(implode(', ', $onboarding_critical_labels))
+                        );
+                        ?>
+                    <?php endif; ?>
+                </p>
+
+                <div class="suple-onboarding-steps">
+                <?php foreach ($onboarding_steps as $step_key => $step):
+                    $completed = !empty($onboarding_state[$step_key]);
+                    $links = $step['links'] ?? [];
+                    $badge_class = $step['badge_class'] ?? 'info';
+                    $aria_label = sprintf(__('Marcar "%s" como completado', 'suple-speed'), $step['title']);
+                ?>
+                <label class="suple-onboarding-card <?php echo $completed ? 'completed' : ''; ?>">
+                    <input type="checkbox"
+                           class="suple-onboarding-step"
+                           data-step="<?php echo esc_attr($step_key); ?>"
+                           aria-label="<?php echo esc_attr($aria_label); ?>"
+                           <?php checked($completed); ?>>
+                    <span class="suple-onboarding-marker" aria-hidden="true">
+                        <span class="dashicons dashicons-yes"></span>
+                    </span>
+                    <div class="suple-onboarding-content">
+                        <h4><?php echo esc_html($step['title']); ?></h4>
+                        <p><?php echo esc_html($step['description']); ?></p>
+
+                        <?php if (!empty($links)): ?>
+                        <div class="suple-onboarding-links">
+                            <?php foreach ($links as $link):
+                                $link_classes = !empty($link['secondary']) ? ' class="secondary"' : '';
+                            ?>
+                            <a href="<?php echo esc_url($link['url']); ?>"<?php echo $link_classes; ?>>
+                                <?php echo esc_html($link['label']); ?>
+                            </a>
+                            <?php endforeach; ?>
+                        </div>
+                        <?php endif; ?>
+
+                        <?php if (!empty($step['badge'])): ?>
+                        <span class="suple-badge <?php echo esc_attr($badge_class); ?>">
+                            <?php echo esc_html($step['badge']); ?>
+                        </span>
+                        <?php endif; ?>
+                    </div>
+                </label>
+                <?php endforeach; ?>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a Getting Started tab entry when onboarding steps exist
- move the onboarding card into a dedicated tab panel so it only shows when active
- keep tab activation logic aligned with the new getting-started slug

## Testing
- php -l views/admin-dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cd8408f3c083308c3379bbf349e200