### PR TITLE
Wrap overview dashboard content in tab panel

### DIFF
--- a/views/admin-dashboard.php
+++ b/views/admin-dashboard.php
@@ -427,374 +427,377 @@ if (empty($active_tab) || !isset($tabs[$active_tab])) {
     </div>
     <?php endif; ?>
 
-    <!-- Stats Overview -->
-    <div class="suple-stats">
-        
-        <!-- Cache Stats -->
-        <div class="suple-stat-card">
-            <span class="suple-stat-value"><?php echo esc_html($dashboard_data['cache_stats']['total_files']); ?></span>
-            <span class="suple-stat-label"><?php _e('Cached Files', 'suple-speed'); ?></span>
-        </div>
-        
-        <!-- Cache Size -->
-        <div class="suple-stat-card">
-            <span class="suple-stat-value"><?php echo esc_html($dashboard_data['cache_stats']['total_size_formatted']); ?></span>
-            <span class="suple-stat-label"><?php _e('Cache Size', 'suple-speed'); ?></span>
-        </div>
-        
-        <!-- Optimized Fonts -->
-        <div class="suple-stat-card">
-            <span class="suple-stat-value"><?php echo esc_html($dashboard_data['fonts_stats']['total_localized']); ?></span>
-            <span class="suple-stat-label"><?php _e('Local Fonts', 'suple-speed'); ?></span>
-        </div>
-        
-        <!-- Performance Score -->
-        <?php if (!empty($dashboard_data['psi_stats']['avg_performance_mobile'])): ?>
-        <div class="suple-stat-card">
-            <span class="suple-stat-value"><?php echo esc_html($dashboard_data['psi_stats']['avg_performance_mobile']); ?></span>
-            <span class="suple-stat-label"><?php _e('Avg Score (Mobile)', 'suple-speed'); ?></span>
-        </div>
-        <?php endif; ?>
+    <div class="suple-tab-panel <?php echo $active_tab === 'overview' ? 'is-active' : ''; ?>" data-tab="overview">
 
-        <div class="suple-stat-card">
-            <span class="suple-stat-value database-size-value"><?php echo esc_html($database_stats['database_size_formatted']); ?></span>
-            <span class="suple-stat-label"><?php _e('DB Size', 'suple-speed'); ?></span>
-        </div>
-
-    </div>
-
-
-                <div class="suple-quick-actions">
-                    <a href="<?php echo esc_url($dashboard_link('performance')); ?>" class="suple-button suple-open-tab" data-tab="performance">
-                        <span class="dashicons dashicons-performance"></span>
-                        <?php _e('Run Performance Test', 'suple-speed'); ?>
-                    </a>
-
-                    <button type="button" class="suple-button suple-purge-cache" data-purge-action="all">
-                        <span class="dashicons dashicons-update"></span>
-                        <?php _e('Purge All Cache', 'suple-speed'); ?>
-                    </button>
-
-                    <a href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings')); ?>" class="suple-button">
-                        <span class="dashicons dashicons-admin-settings"></span>
-                        <?php _e('Configure Settings', 'suple-speed'); ?>
-                    </a>
-                </div>
+        <!-- Stats Overview -->
+        <div class="suple-stats">
+            
+            <!-- Cache Stats -->
+            <div class="suple-stat-card">
+                <span class="suple-stat-value"><?php echo esc_html($dashboard_data['cache_stats']['total_files']); ?></span>
+                <span class="suple-stat-label"><?php _e('Cached Files', 'suple-speed'); ?></span>
             </div>
-
-            <div class="suple-stats">
-                <div class="suple-stat-card">
-                    <span class="suple-stat-value"><?php echo esc_html($cache_stats['total_files']); ?></span>
-                    <span class="suple-stat-label"><?php _e('Cached Files', 'suple-speed'); ?></span>
+            
+            <!-- Cache Size -->
+            <div class="suple-stat-card">
+                <span class="suple-stat-value"><?php echo esc_html($dashboard_data['cache_stats']['total_size_formatted']); ?></span>
+                <span class="suple-stat-label"><?php _e('Cache Size', 'suple-speed'); ?></span>
+            </div>
+            
+            <!-- Optimized Fonts -->
+            <div class="suple-stat-card">
+                <span class="suple-stat-value"><?php echo esc_html($dashboard_data['fonts_stats']['total_localized']); ?></span>
+                <span class="suple-stat-label"><?php _e('Local Fonts', 'suple-speed'); ?></span>
+            </div>
+            
+            <!-- Performance Score -->
+            <?php if (!empty($dashboard_data['psi_stats']['avg_performance_mobile'])): ?>
+            <div class="suple-stat-card">
+                <span class="suple-stat-value"><?php echo esc_html($dashboard_data['psi_stats']['avg_performance_mobile']); ?></span>
+                <span class="suple-stat-label"><?php _e('Avg Score (Mobile)', 'suple-speed'); ?></span>
+            </div>
+            <?php endif; ?>
+    
+            <div class="suple-stat-card">
+                <span class="suple-stat-value database-size-value"><?php echo esc_html($database_stats['database_size_formatted']); ?></span>
+                <span class="suple-stat-label"><?php _e('DB Size', 'suple-speed'); ?></span>
+            </div>
+    
+        </div>
+    
+    
+                    <div class="suple-quick-actions">
+                        <a href="<?php echo esc_url($dashboard_link('performance')); ?>" class="suple-button suple-open-tab" data-tab="performance">
+                            <span class="dashicons dashicons-performance"></span>
+                            <?php _e('Run Performance Test', 'suple-speed'); ?>
+                        </a>
+    
+                        <button type="button" class="suple-button suple-purge-cache" data-purge-action="all">
+                            <span class="dashicons dashicons-update"></span>
+                            <?php _e('Purge All Cache', 'suple-speed'); ?>
+                        </button>
+    
+                        <a href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings')); ?>" class="suple-button">
+                            <span class="dashicons dashicons-admin-settings"></span>
+                            <?php _e('Configure Settings', 'suple-speed'); ?>
+                        </a>
+                    </div>
                 </div>
-
-                <div class="suple-stat-card">
-                    <span class="suple-stat-value"><?php echo esc_html($cache_stats['total_size_formatted']); ?></span>
-                    <span class="suple-stat-label"><?php _e('Cache Size', 'suple-speed'); ?></span>
-                </div>
-
-                <div class="suple-stat-card">
-                    <span class="suple-stat-value"><?php echo esc_html($fonts_stats['total_localized']); ?></span>
-                    <span class="suple-stat-label"><?php _e('Local Fonts', 'suple-speed'); ?></span>
-                </div>
-
-                <?php if (!empty($psi_stats['avg_performance_mobile'])): ?>
+    
+                <div class="suple-stats">
                     <div class="suple-stat-card">
-                        <span class="suple-stat-value"><?php echo esc_html($psi_stats['avg_performance_mobile']); ?></span>
-                        <span class="suple-stat-label"><?php _e('Avg Score (Mobile)', 'suple-speed'); ?></span>
+                        <span class="suple-stat-value"><?php echo esc_html($cache_stats['total_files']); ?></span>
+                        <span class="suple-stat-label"><?php _e('Cached Files', 'suple-speed'); ?></span>
                     </div>
-                <?php endif; ?>
-
-                <div class="suple-stat-card">
-                    <span class="suple-stat-value database-size-value"><?php echo esc_html($database_stats['database_size_formatted']); ?></span>
-                    <span class="suple-stat-label"><?php _e('DB Size', 'suple-speed'); ?></span>
-                </div>
-            </div>
-
-            <div class="suple-grid suple-grid-2">
-                <div>
-                    <div class="suple-card">
-                        <h3><?php _e('Current Status', 'suple-speed'); ?></h3>
-                        <div class="suple-status-grid">
-                            <div class="suple-status-item">
-                                <strong><?php _e('Page Cache', 'suple-speed'); ?></strong>
-                                <span class="suple-badge <?php echo !empty($current_settings['cache_enabled']) ? 'success' : 'error'; ?>">
-                                    <?php echo !empty($current_settings['cache_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
-                                </span>
-                            </div>
-
-                            <div class="suple-status-item">
-                                <strong><?php _e('Assets Optimization', 'suple-speed'); ?></strong>
-                                <span class="suple-badge <?php echo !empty($current_settings['assets_enabled']) ? 'success' : 'error'; ?>">
-                                    <?php echo !empty($current_settings['assets_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
-                                </span>
-                            </div>
-
-                            <div class="suple-status-item">
-                                <strong><?php _e('Compression', 'suple-speed'); ?></strong>
-                                <span class="suple-badge <?php echo !empty($current_settings['compression_enabled']) ? 'success' : 'error'; ?>">
-                                    <?php echo !empty($current_settings['compression_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
-                                </span>
-                            </div>
-
-                            <div class="suple-status-item">
-                                <strong><?php _e('Font Localization', 'suple-speed'); ?></strong>
-                                <span class="suple-badge <?php echo !empty($current_settings['fonts_local']) ? 'success' : 'error'; ?>">
-                                    <?php echo !empty($current_settings['fonts_local']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
-                                </span>
-                            </div>
-
-                            <div class="suple-status-item">
-                                <strong><?php _e('Image Lazy Loading', 'suple-speed'); ?></strong>
-                                <span class="suple-badge <?php echo !empty($current_settings['images_lazy']) ? 'success' : 'error'; ?>">
-                                    <?php echo !empty($current_settings['images_lazy']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
-                                </span>
-                            </div>
-
-                            <?php if (!empty($current_settings['safe_mode'])): ?>
-                                <div class="suple-status-item">
-                                    <strong><?php _e('Safe Mode', 'suple-speed'); ?></strong>
-                                    <span class="suple-badge warning">
-                                        <?php _e('Active', 'suple-speed'); ?>
-                                    </span>
-                                </div>
-                            <?php endif; ?>
-                        </div>
+    
+                    <div class="suple-stat-card">
+                        <span class="suple-stat-value"><?php echo esc_html($cache_stats['total_size_formatted']); ?></span>
+                        <span class="suple-stat-label"><?php _e('Cache Size', 'suple-speed'); ?></span>
                     </div>
-
-                    <?php if (!empty($psi_stats['latest_test'])): ?>
-                        <div class="suple-card">
-                            <h3><?php _e('Latest Performance Test', 'suple-speed'); ?></h3>
-                            <?php
-                            $latest_test     = $psi_stats['latest_test'];
-                            $performance_raw = $latest_test['scores']['performance']['score'] ?? 0;
-                            $performance_val = round((float) $performance_raw);
-                            $score_class     = $performance_val >= 90 ? 'success' : ($performance_val >= 50 ? 'warning' : 'error');
-                            ?>
-                            <div class="suple-performance-score">
-                                <div class="suple-score-circle <?php echo esc_attr($score_class); ?>">
-                                    <span class="suple-score-value"><?php echo esc_html($performance_val); ?></span>
-                                </div>
-                                <p class="suple-text-center suple-text-muted">
-                                    <?php echo esc_html($latest_test['strategy'] ?? ''); ?> •
-                                    <?php echo !empty($latest_test['timestamp']) ? esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $latest_test['timestamp'])) : ''; ?>
-                                </p>
-                                <div class="suple-text-center">
-                                    <a href="<?php echo esc_url($dashboard_link('performance')); ?>" class="suple-button secondary suple-open-tab" data-tab="performance">
-                                        <?php _e('View Details', 'suple-speed'); ?>
-                                    </a>
-                                </div>
-                            </div>
+    
+                    <div class="suple-stat-card">
+                        <span class="suple-stat-value"><?php echo esc_html($fonts_stats['total_localized']); ?></span>
+                        <span class="suple-stat-label"><?php _e('Local Fonts', 'suple-speed'); ?></span>
+                    </div>
+    
+                    <?php if (!empty($psi_stats['avg_performance_mobile'])): ?>
+                        <div class="suple-stat-card">
+                            <span class="suple-stat-value"><?php echo esc_html($psi_stats['avg_performance_mobile']); ?></span>
+                            <span class="suple-stat-label"><?php _e('Avg Score (Mobile)', 'suple-speed'); ?></span>
                         </div>
                     <?php endif; ?>
-
-                    <div class="suple-card">
-                        <h3><?php _e('Recent Activity', 'suple-speed'); ?></h3>
-                        <div id="recent-activity">
-                            <p class="suple-text-muted"><?php _e('Loading recent activity...', 'suple-speed'); ?></p>
-                        </div>
-                        <div class="suple-text-center suple-mt-1">
-                            <a href="<?php echo esc_url($dashboard_link('logs')); ?>" class="suple-button secondary suple-open-tab" data-tab="logs">
-                                <?php _e('Open Logs', 'suple-speed'); ?>
-                            </a>
-                        </div>
+    
+                    <div class="suple-stat-card">
+                        <span class="suple-stat-value database-size-value"><?php echo esc_html($database_stats['database_size_formatted']); ?></span>
+                        <span class="suple-stat-label"><?php _e('DB Size', 'suple-speed'); ?></span>
                     </div>
                 </div>
-
-                <div>
-                    <div class="suple-card">
-                        <h3><?php _e('Quick Tools', 'suple-speed'); ?></h3>
-                        <div class="suple-quick-tools">
-                            <div class="suple-tool-group">
-                                <h4><?php _e('Cache Management', 'suple-speed'); ?></h4>
-                                <div class="suple-button-group">
-                                    <button type="button" class="suple-button suple-purge-cache" data-purge-action="all">
-                                        <?php _e('Purge All', 'suple-speed'); ?>
-                                    </button>
-                                    <button type="button" class="suple-button secondary suple-purge-cache" data-purge-action="url" data-url="<?php echo esc_url(home_url('/')); ?>">
-                                        <?php _e('Purge Homepage', 'suple-speed'); ?>
-                                    </button>
-                                </div>
-                            </div>
-
-                            <div class="suple-tool-group">
-                                <h4><?php _e('Font Optimization', 'suple-speed'); ?></h4>
-                                <div class="suple-button-group">
-                                    <a href="<?php echo esc_url($dashboard_link('fonts')); ?>" class="suple-button suple-open-tab" data-tab="fonts">
-                                        <?php _e('Manage Fonts', 'suple-speed'); ?>
-                                    </a>
-                                    <button type="button" class="suple-button secondary suple-scan-fonts">
-                                        <?php _e('Scan for Fonts', 'suple-speed'); ?>
-                                    </button>
-                                </div>
-                            </div>
-
-                            <div class="suple-tool-group">
-                                <h4><?php _e('Asset Optimization', 'suple-speed'); ?></h4>
-                                <div class="suple-button-group">
-                                    <a href="<?php echo esc_url($dashboard_link('assets')); ?>" class="suple-button suple-open-tab" data-tab="assets">
-                                        <?php _e('Manage Assets', 'suple-speed'); ?>
-                                    </a>
-                                    <button type="button" class="suple-button secondary suple-scan-handles">
-                                        <?php _e('Scan Handles', 'suple-speed'); ?>
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="suple-card suple-database-summary">
-                        <h3><?php _e('Database Health', 'suple-speed'); ?></h3>
-                        <div class="suple-stats">
-                            <div class="suple-stat-card">
-                                <span class="suple-stat-value database-total-revisions"><?php echo esc_html(number_format_i18n((int) $database_stats['total_revisions'])); ?></span>
-                                <span class="suple-stat-label"><?php _e('Post Revisions', 'suple-speed'); ?></span>
-                            </div>
-                            <div class="suple-stat-card">
-                                <span class="suple-stat-value database-expired-transients"><?php echo esc_html(number_format_i18n((int) $database_stats['expired_transients'])); ?></span>
-                                <span class="suple-stat-label"><?php _e('Expired Transients', 'suple-speed'); ?></span>
-                            </div>
-                            <div class="suple-stat-card">
-                                <span class="suple-stat-value database-tables-needing-optimization"><?php echo esc_html(number_format_i18n((int) $database_stats['tables_needing_optimization'])); ?></span>
-                                <span class="suple-stat-label"><?php _e('Tables w/ Overhead', 'suple-speed'); ?></span>
-                            </div>
-                        </div>
-                        <p class="suple-text-muted database-optimization-status">
-                            <?php
-                            echo wp_kses_post(
-                                sprintf(
-                                    __('Tables needing optimization: %1$s of %2$s', 'suple-speed'),
-                                    '<strong class="database-tables-needing-optimization">' . esc_html(number_format_i18n((int) $database_stats['tables_needing_optimization'])) . '</strong>',
-                                    '<span class="database-total-tables">' . esc_html(number_format_i18n((int) $database_stats['total_tables'])) . '</span>'
-                                )
-                            );
-                            ?>
-                        </p>
-                        <ul class="suple-database-meta">
-                            <li>
-                                <strong><?php _e('Last revision cleanup', 'suple-speed'); ?>:</strong>
-                                <span class="database-last-revision">
-                                    <?php
-                                    if (!empty($database_stats['last_revision_cleanup_human'])) {
-                                        printf(
-                                            esc_html__('%s ago', 'suple-speed'),
-                                            esc_html($database_stats['last_revision_cleanup_human'])
-                                        );
-                                    } else {
-                                        esc_html_e('Never', 'suple-speed');
-                                    }
-                                    ?>
-                                </span>
-                            </li>
-                            <li>
-                                <strong><?php _e('Last transient cleanup', 'suple-speed'); ?>:</strong>
-                                <span class="database-last-transients">
-                                    <?php
-                                    if (!empty($database_stats['last_transients_cleanup_human'])) {
-                                        printf(
-                                            esc_html__('%s ago', 'suple-speed'),
-                                            esc_html($database_stats['last_transients_cleanup_human'])
-                                        );
-                                    } else {
-                                        esc_html_e('Never', 'suple-speed');
-                                    }
-                                    ?>
-                                </span>
-                            </li>
-                            <li>
-                                <strong><?php _e('Last optimization', 'suple-speed'); ?>:</strong>
-                                <span class="database-last-optimization">
-                                    <?php
-                                    if (!empty($database_stats['last_optimization_human'])) {
-                                        printf(
-                                            esc_html__('%s ago', 'suple-speed'),
-                                            esc_html($database_stats['last_optimization_human'])
-                                        );
-                                    } else {
-                                        esc_html_e('Never', 'suple-speed');
-                                    }
-                                    ?>
-                                </span>
-                            </li>
-                        </ul>
-                        <div class="suple-button-group suple-mt-1">
-                            <a href="<?php echo esc_url($dashboard_link('database')); ?>" class="suple-button secondary suple-open-tab" data-tab="database">
-                                <?php _e('Open Database Tools', 'suple-speed'); ?>
-                            </a>
-                        </div>
-                    </div>
-
-                    <div class="suple-card">
-                        <h3><?php _e('System Information', 'suple-speed'); ?></h3>
-                        <table class="suple-table">
-                            <tbody>
-                                <tr>
-                                    <td><strong><?php _e('WordPress Version', 'suple-speed'); ?></strong></td>
-                                    <td><?php echo esc_html($dashboard_data['wp_version']); ?></td>
-                                </tr>
-                                <tr>
-                                    <td><strong><?php _e('PHP Version', 'suple-speed'); ?></strong></td>
-                                    <td><?php echo esc_html($dashboard_data['php_version']); ?></td>
-                                </tr>
-                                <tr>
-                                    <td><strong><?php _e('Memory Limit', 'suple-speed'); ?></strong></td>
-                                    <td><?php echo esc_html($server_caps['memory_limit']); ?></td>
-                                </tr>
-                                <tr>
-                                    <td><strong><?php _e('WebP Support', 'suple-speed'); ?></strong></td>
-                                    <td>
-                                        <span class="suple-badge <?php echo !empty($server_caps['webp_support']) ? 'success' : 'error'; ?>">
-                                            <?php echo !empty($server_caps['webp_support']) ? esc_html__('Yes', 'suple-speed') : esc_html__('No', 'suple-speed'); ?>
-                                        </span>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td><strong><?php _e('AVIF Support', 'suple-speed'); ?></strong></td>
-                                    <td>
-                                        <span class="suple-badge <?php echo !empty($server_caps['avif_support']) ? 'success' : 'error'; ?>">
-                                            <?php echo !empty($server_caps['avif_support']) ? esc_html__('Yes', 'suple-speed') : esc_html__('No', 'suple-speed'); ?>
-                                        </span>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td><strong><?php _e('OPCache', 'suple-speed'); ?></strong></td>
-                                    <td>
-                                        <span class="suple-badge <?php echo !empty($server_caps['opcache_enabled']) ? 'success' : 'warning'; ?>">
-                                            <?php echo !empty($server_caps['opcache_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
-                                        </span>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-
-                    <?php if (!empty($compat_report['detected_plugins'])): ?>
+    
+                <div class="suple-grid suple-grid-2">
+                    <div>
                         <div class="suple-card">
-                            <h3><?php _e('Detected Plugins', 'suple-speed'); ?></h3>
-                            <div class="suple-compat-plugins">
-                                <?php foreach ($compat_report['detected_plugins'] as $plugin_key => $plugin_info): ?>
-                                    <div class="suple-compat-plugin">
-                                        <strong><?php echo esc_html($plugin_info['name'] ?? $plugin_key); ?></strong>
-                                        <span class="suple-badge success"><?php _e('Compatible', 'suple-speed'); ?></span><br>
-                                        <small class="suple-text-muted">v<?php echo esc_html($plugin_info['version'] ?? ''); ?></small>
+                            <h3><?php _e('Current Status', 'suple-speed'); ?></h3>
+                            <div class="suple-status-grid">
+                                <div class="suple-status-item">
+                                    <strong><?php _e('Page Cache', 'suple-speed'); ?></strong>
+                                    <span class="suple-badge <?php echo !empty($current_settings['cache_enabled']) ? 'success' : 'error'; ?>">
+                                        <?php echo !empty($current_settings['cache_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                                    </span>
+                                </div>
+    
+                                <div class="suple-status-item">
+                                    <strong><?php _e('Assets Optimization', 'suple-speed'); ?></strong>
+                                    <span class="suple-badge <?php echo !empty($current_settings['assets_enabled']) ? 'success' : 'error'; ?>">
+                                        <?php echo !empty($current_settings['assets_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                                    </span>
+                                </div>
+    
+                                <div class="suple-status-item">
+                                    <strong><?php _e('Compression', 'suple-speed'); ?></strong>
+                                    <span class="suple-badge <?php echo !empty($current_settings['compression_enabled']) ? 'success' : 'error'; ?>">
+                                        <?php echo !empty($current_settings['compression_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                                    </span>
+                                </div>
+    
+                                <div class="suple-status-item">
+                                    <strong><?php _e('Font Localization', 'suple-speed'); ?></strong>
+                                    <span class="suple-badge <?php echo !empty($current_settings['fonts_local']) ? 'success' : 'error'; ?>">
+                                        <?php echo !empty($current_settings['fonts_local']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                                    </span>
+                                </div>
+    
+                                <div class="suple-status-item">
+                                    <strong><?php _e('Image Lazy Loading', 'suple-speed'); ?></strong>
+                                    <span class="suple-badge <?php echo !empty($current_settings['images_lazy']) ? 'success' : 'error'; ?>">
+                                        <?php echo !empty($current_settings['images_lazy']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                                    </span>
+                                </div>
+    
+                                <?php if (!empty($current_settings['safe_mode'])): ?>
+                                    <div class="suple-status-item">
+                                        <strong><?php _e('Safe Mode', 'suple-speed'); ?></strong>
+                                        <span class="suple-badge warning">
+                                            <?php _e('Active', 'suple-speed'); ?>
+                                        </span>
                                     </div>
-                                <?php endforeach; ?>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+    
+                        <?php if (!empty($psi_stats['latest_test'])): ?>
+                            <div class="suple-card">
+                                <h3><?php _e('Latest Performance Test', 'suple-speed'); ?></h3>
+                                <?php
+                                $latest_test     = $psi_stats['latest_test'];
+                                $performance_raw = $latest_test['scores']['performance']['score'] ?? 0;
+                                $performance_val = round((float) $performance_raw);
+                                $score_class     = $performance_val >= 90 ? 'success' : ($performance_val >= 50 ? 'warning' : 'error');
+                                ?>
+                                <div class="suple-performance-score">
+                                    <div class="suple-score-circle <?php echo esc_attr($score_class); ?>">
+                                        <span class="suple-score-value"><?php echo esc_html($performance_val); ?></span>
+                                    </div>
+                                    <p class="suple-text-center suple-text-muted">
+                                        <?php echo esc_html($latest_test['strategy'] ?? ''); ?> •
+                                        <?php echo !empty($latest_test['timestamp']) ? esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $latest_test['timestamp'])) : ''; ?>
+                                    </p>
+                                    <div class="suple-text-center">
+                                        <a href="<?php echo esc_url($dashboard_link('performance')); ?>" class="suple-button secondary suple-open-tab" data-tab="performance">
+                                            <?php _e('View Details', 'suple-speed'); ?>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+    
+                        <div class="suple-card">
+                            <h3><?php _e('Recent Activity', 'suple-speed'); ?></h3>
+                            <div id="recent-activity">
+                                <p class="suple-text-muted"><?php _e('Loading recent activity...', 'suple-speed'); ?></p>
                             </div>
                             <div class="suple-text-center suple-mt-1">
-                                <a href="<?php echo esc_url($dashboard_link('compatibility')); ?>" class="suple-button secondary suple-open-tab" data-tab="compatibility">
-                                    <?php _e('View Compatibility Report', 'suple-speed'); ?>
+                                <a href="<?php echo esc_url($dashboard_link('logs')); ?>" class="suple-button secondary suple-open-tab" data-tab="logs">
+                                    <?php _e('Open Logs', 'suple-speed'); ?>
                                 </a>
                             </div>
                         </div>
-                    <?php endif; ?>
+                    </div>
+    
+                    <div>
+                        <div class="suple-card">
+                            <h3><?php _e('Quick Tools', 'suple-speed'); ?></h3>
+                            <div class="suple-quick-tools">
+                                <div class="suple-tool-group">
+                                    <h4><?php _e('Cache Management', 'suple-speed'); ?></h4>
+                                    <div class="suple-button-group">
+                                        <button type="button" class="suple-button suple-purge-cache" data-purge-action="all">
+                                            <?php _e('Purge All', 'suple-speed'); ?>
+                                        </button>
+                                        <button type="button" class="suple-button secondary suple-purge-cache" data-purge-action="url" data-url="<?php echo esc_url(home_url('/')); ?>">
+                                            <?php _e('Purge Homepage', 'suple-speed'); ?>
+                                        </button>
+                                    </div>
+                                </div>
+    
+                                <div class="suple-tool-group">
+                                    <h4><?php _e('Font Optimization', 'suple-speed'); ?></h4>
+                                    <div class="suple-button-group">
+                                        <a href="<?php echo esc_url($dashboard_link('fonts')); ?>" class="suple-button suple-open-tab" data-tab="fonts">
+                                            <?php _e('Manage Fonts', 'suple-speed'); ?>
+                                        </a>
+                                        <button type="button" class="suple-button secondary suple-scan-fonts">
+                                            <?php _e('Scan for Fonts', 'suple-speed'); ?>
+                                        </button>
+                                    </div>
+                                </div>
+    
+                                <div class="suple-tool-group">
+                                    <h4><?php _e('Asset Optimization', 'suple-speed'); ?></h4>
+                                    <div class="suple-button-group">
+                                        <a href="<?php echo esc_url($dashboard_link('assets')); ?>" class="suple-button suple-open-tab" data-tab="assets">
+                                            <?php _e('Manage Assets', 'suple-speed'); ?>
+                                        </a>
+                                        <button type="button" class="suple-button secondary suple-scan-handles">
+                                            <?php _e('Scan Handles', 'suple-speed'); ?>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+    
+                        <div class="suple-card suple-database-summary">
+                            <h3><?php _e('Database Health', 'suple-speed'); ?></h3>
+                            <div class="suple-stats">
+                                <div class="suple-stat-card">
+                                    <span class="suple-stat-value database-total-revisions"><?php echo esc_html(number_format_i18n((int) $database_stats['total_revisions'])); ?></span>
+                                    <span class="suple-stat-label"><?php _e('Post Revisions', 'suple-speed'); ?></span>
+                                </div>
+                                <div class="suple-stat-card">
+                                    <span class="suple-stat-value database-expired-transients"><?php echo esc_html(number_format_i18n((int) $database_stats['expired_transients'])); ?></span>
+                                    <span class="suple-stat-label"><?php _e('Expired Transients', 'suple-speed'); ?></span>
+                                </div>
+                                <div class="suple-stat-card">
+                                    <span class="suple-stat-value database-tables-needing-optimization"><?php echo esc_html(number_format_i18n((int) $database_stats['tables_needing_optimization'])); ?></span>
+                                    <span class="suple-stat-label"><?php _e('Tables w/ Overhead', 'suple-speed'); ?></span>
+                                </div>
+                            </div>
+                            <p class="suple-text-muted database-optimization-status">
+                                <?php
+                                echo wp_kses_post(
+                                    sprintf(
+                                        __('Tables needing optimization: %1$s of %2$s', 'suple-speed'),
+                                        '<strong class="database-tables-needing-optimization">' . esc_html(number_format_i18n((int) $database_stats['tables_needing_optimization'])) . '</strong>',
+                                        '<span class="database-total-tables">' . esc_html(number_format_i18n((int) $database_stats['total_tables'])) . '</span>'
+                                    )
+                                );
+                                ?>
+                            </p>
+                            <ul class="suple-database-meta">
+                                <li>
+                                    <strong><?php _e('Last revision cleanup', 'suple-speed'); ?>:</strong>
+                                    <span class="database-last-revision">
+                                        <?php
+                                        if (!empty($database_stats['last_revision_cleanup_human'])) {
+                                            printf(
+                                                esc_html__('%s ago', 'suple-speed'),
+                                                esc_html($database_stats['last_revision_cleanup_human'])
+                                            );
+                                        } else {
+                                            esc_html_e('Never', 'suple-speed');
+                                        }
+                                        ?>
+                                    </span>
+                                </li>
+                                <li>
+                                    <strong><?php _e('Last transient cleanup', 'suple-speed'); ?>:</strong>
+                                    <span class="database-last-transients">
+                                        <?php
+                                        if (!empty($database_stats['last_transients_cleanup_human'])) {
+                                            printf(
+                                                esc_html__('%s ago', 'suple-speed'),
+                                                esc_html($database_stats['last_transients_cleanup_human'])
+                                            );
+                                        } else {
+                                            esc_html_e('Never', 'suple-speed');
+                                        }
+                                        ?>
+                                    </span>
+                                </li>
+                                <li>
+                                    <strong><?php _e('Last optimization', 'suple-speed'); ?>:</strong>
+                                    <span class="database-last-optimization">
+                                        <?php
+                                        if (!empty($database_stats['last_optimization_human'])) {
+                                            printf(
+                                                esc_html__('%s ago', 'suple-speed'),
+                                                esc_html($database_stats['last_optimization_human'])
+                                            );
+                                        } else {
+                                            esc_html_e('Never', 'suple-speed');
+                                        }
+                                        ?>
+                                    </span>
+                                </li>
+                            </ul>
+                            <div class="suple-button-group suple-mt-1">
+                                <a href="<?php echo esc_url($dashboard_link('database')); ?>" class="suple-button secondary suple-open-tab" data-tab="database">
+                                    <?php _e('Open Database Tools', 'suple-speed'); ?>
+                                </a>
+                            </div>
+                        </div>
+    
+                        <div class="suple-card">
+                            <h3><?php _e('System Information', 'suple-speed'); ?></h3>
+                            <table class="suple-table">
+                                <tbody>
+                                    <tr>
+                                        <td><strong><?php _e('WordPress Version', 'suple-speed'); ?></strong></td>
+                                        <td><?php echo esc_html($dashboard_data['wp_version']); ?></td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong><?php _e('PHP Version', 'suple-speed'); ?></strong></td>
+                                        <td><?php echo esc_html($dashboard_data['php_version']); ?></td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong><?php _e('Memory Limit', 'suple-speed'); ?></strong></td>
+                                        <td><?php echo esc_html($server_caps['memory_limit']); ?></td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong><?php _e('WebP Support', 'suple-speed'); ?></strong></td>
+                                        <td>
+                                            <span class="suple-badge <?php echo !empty($server_caps['webp_support']) ? 'success' : 'error'; ?>">
+                                                <?php echo !empty($server_caps['webp_support']) ? esc_html__('Yes', 'suple-speed') : esc_html__('No', 'suple-speed'); ?>
+                                            </span>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong><?php _e('AVIF Support', 'suple-speed'); ?></strong></td>
+                                        <td>
+                                            <span class="suple-badge <?php echo !empty($server_caps['avif_support']) ? 'success' : 'error'; ?>">
+                                                <?php echo !empty($server_caps['avif_support']) ? esc_html__('Yes', 'suple-speed') : esc_html__('No', 'suple-speed'); ?>
+                                            </span>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong><?php _e('OPCache', 'suple-speed'); ?></strong></td>
+                                        <td>
+                                            <span class="suple-badge <?php echo !empty($server_caps['opcache_enabled']) ? 'success' : 'warning'; ?>">
+                                                <?php echo !empty($server_caps['opcache_enabled']) ? esc_html__('Enabled', 'suple-speed') : esc_html__('Disabled', 'suple-speed'); ?>
+                                            </span>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+    
+                        <?php if (!empty($compat_report['detected_plugins'])): ?>
+                            <div class="suple-card">
+                                <h3><?php _e('Detected Plugins', 'suple-speed'); ?></h3>
+                                <div class="suple-compat-plugins">
+                                    <?php foreach ($compat_report['detected_plugins'] as $plugin_key => $plugin_info): ?>
+                                        <div class="suple-compat-plugin">
+                                            <strong><?php echo esc_html($plugin_info['name'] ?? $plugin_key); ?></strong>
+                                            <span class="suple-badge success"><?php _e('Compatible', 'suple-speed'); ?></span><br>
+                                            <small class="suple-text-muted">v<?php echo esc_html($plugin_info['version'] ?? ''); ?></small>
+                                        </div>
+                                    <?php endforeach; ?>
+                                </div>
+                                <div class="suple-text-center suple-mt-1">
+                                    <a href="<?php echo esc_url($dashboard_link('compatibility')); ?>" class="suple-button secondary suple-open-tab" data-tab="compatibility">
+                                        <?php _e('View Compatibility Report', 'suple-speed'); ?>
+                                    </a>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                    </div>
                 </div>
+    
+                <div id="scan-results" style="display:none;"></div>
             </div>
+    </div>
 
-            <div id="scan-results" style="display:none;"></div>
-        </div>
-
-        <!-- Performance Tab -->
-        <div class="suple-tab-panel <?php echo $active_tab === 'performance' ? 'is-active' : ''; ?>" data-tab="performance">
+    <!-- Performance Tab -->
+    <div class="suple-tab-panel <?php echo $active_tab === 'performance' ? 'is-active' : ''; ?>" data-tab="performance">
             <div class="suple-grid suple-grid-2 suple-mt-2">
                 <div class="suple-card">
                     <h3><?php _e('Performance Overview', 'suple-speed'); ?></h3>


### PR DESCRIPTION
## Summary
- wrap the overview statistics, quick actions, and status cards in a `suple-tab-panel` container so they respond to tab changes
- keep the getting-started panel separate and ensure the overview tab panel closes before other sections begin

## Testing
- php -l views/admin-dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cd90a4db2883309318fed5042f829e