### PR TITLE
Add notice log level support

### DIFF
--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -12,6 +12,7 @@ class Logger {
      */
     const LEVEL_DEBUG = 'debug';
     const LEVEL_INFO = 'info';
+    const LEVEL_NOTICE = 'notice';
     const LEVEL_WARNING = 'warning';
     const LEVEL_ERROR = 'error';
     const LEVEL_CRITICAL = 'critical';
@@ -78,7 +79,14 @@ class Logger {
     public function info($message, $context = [], $module = 'general') {
         $this->log(self::LEVEL_INFO, $message, $context, $module);
     }
-    
+
+    /**
+     * Log de notice
+     */
+    public function notice($message, $context = [], $module = 'general') {
+        $this->log(self::LEVEL_NOTICE, $message, $context, $module);
+    }
+
     /**
      * Log de warning
      */
@@ -107,14 +115,15 @@ class Logger {
         $levels = [
             self::LEVEL_DEBUG => 0,
             self::LEVEL_INFO => 1,
-            self::LEVEL_WARNING => 2,
-            self::LEVEL_ERROR => 3,
-            self::LEVEL_CRITICAL => 4
+            self::LEVEL_NOTICE => 2,
+            self::LEVEL_WARNING => 3,
+            self::LEVEL_ERROR => 4,
+            self::LEVEL_CRITICAL => 5,
         ];
-        
+
         $current_level = $levels[$this->log_level] ?? 1;
         $message_level = $levels[$level] ?? 1;
-        
+
         return $message_level >= $current_level;
     }
     

--- a/views/admin-settings.php
+++ b/views/admin-settings.php
@@ -90,6 +90,7 @@ if ($assets_module && method_exists($assets_module, 'get_preload_recommendations
                         <select id="log_level" name="log_level" class="suple-form-input">
                             <option value="debug" <?php selected($current_settings['log_level'] ?? 'info', 'debug'); ?>><?php _e('Debug', 'suple-speed'); ?></option>
                             <option value="info" <?php selected($current_settings['log_level'] ?? 'info', 'info'); ?>><?php _e('Info', 'suple-speed'); ?></option>
+                            <option value="notice" <?php selected($current_settings['log_level'] ?? 'info', 'notice'); ?>><?php _e('Notice', 'suple-speed'); ?></option>
                             <option value="warning" <?php selected($current_settings['log_level'] ?? 'info', 'warning'); ?>><?php _e('Warning', 'suple-speed'); ?></option>
                             <option value="error" <?php selected($current_settings['log_level'] ?? 'info', 'error'); ?>><?php _e('Error', 'suple-speed'); ?></option>
                         </select>


### PR DESCRIPTION
## Summary
- add a notice log level constant and helper to the logger so existing notice calls work
- include the notice level in the log level priority map between info and warning
- expose the notice option in the admin log level selector so stored notice values remain selectable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd955b3100833093a717f08716b9d1