### PR TITLE
Add cache settings shortcut in dashboard cache status card

### DIFF
--- a/views/admin-dashboard.php
+++ b/views/admin-dashboard.php
@@ -893,6 +893,11 @@ if (empty($active_tab) || !isset($tabs[$active_tab])) {
                         </li>
                     </ul>
                     <div class="suple-mt-2">
+                        <a class="suple-button" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-cache')); ?>">
+                            <?php _e('Adjust Cache Settings', 'suple-speed'); ?>
+                        </a>
+                    </div>
+                    <div class="suple-mt-2">
                         <button type="button" class="suple-button suple-purge-cache" data-purge-action="all">
                             <span class="dashicons dashicons-update"></span>
                             <?php _e('Purge Entire Cache', 'suple-speed'); ?>


### PR DESCRIPTION
## Summary
- add a cache settings shortcut link to the cache status card in the admin dashboard
- keep existing purge controls below the new settings link to retain functionality

## Testing
- php -l views/admin-dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cdaf35e4fc83309f3dee5f132ccf20