### PR TITLE
Update critical tab edit link

### DIFF
--- a/views/admin-dashboard.php
+++ b/views/admin-dashboard.php
@@ -1009,7 +1009,7 @@ if (empty($active_tab) || !isset($tabs[$active_tab])) {
                     <?php else: ?>
                         <p><?php _e('No critical CSS has been configured yet. You can add one in the settings panel.', 'suple-speed'); ?></p>
                     <?php endif; ?>
-                    <a class="suple-button" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-assets')); ?>">
+                    <a class="suple-button" href="<?php echo esc_url(admin_url('admin.php?page=suple-speed-settings#tab-critical')); ?>">
                         <?php _e('Edit Critical CSS', 'suple-speed'); ?>
                     </a>
                 </div>


### PR DESCRIPTION
## Summary
- point the critical tab action button to the critical settings section instead of the assets section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdaf36cc3c8330b06221cff111188f