### PR TITLE
Improve admin tab navigation styling

### DIFF
--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -459,32 +459,49 @@
 .suple-tab-nav {
     border-bottom: 1px solid var(--suple-border);
     margin-bottom: 20px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-gutter: stable;
+    padding-bottom: 8px;
 }
 
 .suple-tab-nav ul {
     display: flex;
+    flex-wrap: nowrap;
     margin: 0;
     padding: 0;
     list-style: none;
+    gap: 12px;
 }
 
 .suple-tab-nav li {
-    margin-right: 20px;
+    flex: 0 0 auto;
 }
 
 .suple-tab-nav a {
     display: block;
-    padding: 12px 16px;
+    padding: 10px 18px;
     text-decoration: none;
     color: var(--suple-text-light);
-    border-bottom: 2px solid transparent;
+    background: #fff;
+    border: 1px solid var(--suple-border);
+    border-radius: calc(var(--suple-radius) + 2px);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
     transition: all 0.2s ease;
 }
 
 .suple-tab-nav a:hover,
+.suple-tab-nav a:focus {
+    color: var(--suple-primary);
+    border-color: var(--suple-primary);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
 .suple-tab-nav a.active {
     color: var(--suple-primary);
-    border-bottom-color: var(--suple-primary);
+    border-color: var(--suple-primary);
+    box-shadow: 0 2px 8px rgba(34, 113, 177, 0.15);
+    font-weight: 600;
 }
 
 .suple-tab-content {


### PR DESCRIPTION
## Summary
- allow the admin tab navigation to scroll horizontally with touch momentum
- keep tabs on a single row while letting each entry size to its content
- refresh tab styling with white card-like buttons and clearer active states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdbb3cb82c8330967b0685479ac9b1