### PR TITLE
Allow admin tab navigation to wrap on smaller widths

### DIFF
--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -467,7 +467,7 @@
 
 .suple-tab-nav ul {
     display: flex;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -475,7 +475,7 @@
 }
 
 .suple-tab-nav li {
-    flex: 0 0 auto;
+    flex: 0 1 auto;
 }
 
 .suple-tab-nav a {
@@ -495,6 +495,8 @@
     color: var(--suple-primary);
     border-color: var(--suple-primary);
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    outline: 2px solid var(--suple-primary);
+    outline-offset: 2px;
 }
 
 .suple-tab-nav a.active {
@@ -502,6 +504,32 @@
     border-color: var(--suple-primary);
     box-shadow: 0 2px 8px rgba(34, 113, 177, 0.15);
     font-weight: 600;
+}
+
+@media (max-width: 1200px) {
+    .suple-tab-nav ul {
+        gap: 8px;
+    }
+
+    .suple-tab-nav li {
+        flex: 1 1 220px;
+        min-width: 160px;
+    }
+
+    .suple-tab-nav a {
+        padding: 8px 14px;
+        font-size: 13px;
+    }
+}
+
+@media (max-width: 782px) {
+    .suple-tab-nav li {
+        flex-basis: 100%;
+    }
+
+    .suple-tab-nav a {
+        text-align: center;
+    }
 }
 
 .suple-tab-content {


### PR DESCRIPTION
## Summary
- allow the admin tab navigation list to wrap to multiple lines by letting items shrink and wrap as space is limited
- adjust tab spacing and padding at tablet breakpoints while keeping hover/active/focus treatments intact
- center tabs on small mobile widths to keep every tab reachable without horizontal scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdbdb1f1dc8330b49045496696ea99