### PR TITLE
Add missing endif for onboarding section

### DIFF
--- a/views/admin-dashboard.php
+++ b/views/admin-dashboard.php
@@ -514,7 +514,8 @@ $onboarding_critical_labels = array_map(
     
                 <div id="scan-results" style="display:none;"></div>
             </div>
-    </div>
+        </section>
+    <?php endif; ?>
 
     <!-- Performance Tab -->
     <div class="suple-tab-panel <?php echo $active_tab === 'performance' ? 'is-active' : ''; ?>" data-tab="performance">


### PR DESCRIPTION
## Summary
- close the onboarding dashboard block with a </section>
- add the missing `endif` for the onboarding conditional

## Testing
- php -l views/admin-dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cdc85b433883308f2cc6a3f6516eaf