### PR TITLE
Ensure admin drag and drop loads sortable

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -491,7 +491,7 @@ class Admin {
         wp_enqueue_script(
             'suple-speed-admin',
             SUPLE_SPEED_PLUGIN_URL . 'public/js/admin.js',
-            ['jquery', 'wp-util'],
+            ['jquery', 'wp-util', 'jquery-ui-sortable'],
             $version,
             true
         );

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2387,6 +2387,10 @@
 
         initDragDrop: function() {
             // Implementar drag & drop para reordenar elementos
+            if (typeof $.fn.sortable !== 'function') {
+                return;
+            }
+
             $('.suple-sortable').sortable({
                 handle: '.suple-drag-handle',
                 update: function() {


### PR DESCRIPTION
## Summary
- add the jQuery UI sortable dependency to the admin script loader so the sortable widget is available
- guard the drag-and-drop initializer in admin.js when the sortable plugin fails to load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdcc0ea15083309c33bedea8c9367b